### PR TITLE
Formatted Python code using black

### DIFF
--- a/feeding_web_app_ros2_test/feeding_web_app_ros2_test/publisher.py
+++ b/feeding_web_app_ros2_test/feeding_web_app_ros2_test/publisher.py
@@ -6,17 +6,16 @@ from std_msgs.msg import String
 
 
 class MinimalPublisher(Node):
-
     def __init__(self):
-        super().__init__('minimal_publisher')
-        self.publisher_ = self.create_publisher(String, 'test_topic', 10)
+        super().__init__("minimal_publisher")
+        self.publisher_ = self.create_publisher(String, "test_topic", 10)
         timer_period = 0.5  # seconds
         self.timer = self.create_timer(timer_period, self.timer_callback)
         self.i = 0
 
     def timer_callback(self):
         msg = String()
-        msg.data = 'Hello World: %d' % self.i
+        msg.data = "Hello World: %d" % self.i
         self.publisher_.publish(msg)
         self.get_logger().info('Publishing: "%s"' % msg.data)
         self.i += 1
@@ -36,5 +35,5 @@ def main(args=None):
     rclpy.shutdown()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/feeding_web_app_ros2_test/feeding_web_app_ros2_test/reverse_string_service.py
+++ b/feeding_web_app_ros2_test/feeding_web_app_ros2_test/reverse_string_service.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
-from feeding_web_app_ros2_msgs.srv import ReverseString                                                           # CHANGE
+from feeding_web_app_ros2_msgs.srv import ReverseString  # CHANGE
 
 import rclpy
 from rclpy.node import Node
 
 
 class MinimalService(Node):
-
     def __init__(self):
-        super().__init__('reverse_string')
-        self.srv = self.create_service(ReverseString, 'reverse_string', self.reverse_string_callback)
+        super().__init__("reverse_string")
+        self.srv = self.create_service(
+            ReverseString, "reverse_string", self.reverse_string_callback
+        )
 
     def reverse_string_callback(self, request, response):
         response.reversed = request.input[::-1]
-        self.get_logger().info('Incoming request\ninput: %s' % (request.input))
+        self.get_logger().info("Incoming request\ninput: %s" % (request.input))
         return response
+
 
 def main(args=None):
     rclpy.init(args=args)
@@ -25,5 +27,6 @@ def main(args=None):
 
     rclpy.shutdown()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/feeding_web_app_ros2_test/feeding_web_app_ros2_test/sort_by_character_frequency_action.py
+++ b/feeding_web_app_ros2_test/feeding_web_app_ros2_test/sort_by_character_frequency_action.py
@@ -9,32 +9,35 @@ from rclpy.node import Node
 import inspect
 from feeding_web_app_ros2_msgs.action import SortByCharacterFrequency
 
-class MinimalAction(Node):
 
+class MinimalAction(Node):
     def __init__(self, sleep_time=0.1):
-        super().__init__('sort_by_character_frequency')
+        super().__init__("sort_by_character_frequency")
         self.sleep_time = sleep_time
         self._action_server = ActionServer(
             self,
             SortByCharacterFrequency,
-            'sort_by_character_frequency',
+            "sort_by_character_frequency",
             self.execute_callback,
             goal_callback=self.goal_callback,
-            cancel_callback=self.cancel_callback)
+            cancel_callback=self.cancel_callback,
+        )
 
     def goal_callback(self, goal_request):
         """Accept or reject a client request to begin an action."""
         # This server allows multiple goals in parallel
-        self.get_logger().info('Received goal request')
+        self.get_logger().info("Received goal request")
         return GoalResponse.ACCEPT
 
     def cancel_callback(self, goal_handle):
         """Accept or reject a client request to cancel an action."""
-        self.get_logger().info('Received cancel request')
+        self.get_logger().info("Received cancel request")
         return CancelResponse.ACCEPT
 
     async def execute_callback(self, goal_handle):
-        self.get_logger().info('Executing goal...%s | %s' % (goal_handle, repr(goal_handle.request.input)))
+        self.get_logger().info(
+            "Executing goal...%s | %s" % (goal_handle, repr(goal_handle.request.input))
+        )
         input = goal_handle.request.input
 
         feedback_msg = SortByCharacterFrequency.Feedback()
@@ -43,7 +46,7 @@ class MinimalAction(Node):
         for i in range(len(input)):
             # Check if there is a cancel request
             if goal_handle.is_cancel_requested:
-                self.get_logger().info('Goal canceled')
+                self.get_logger().info("Goal canceled")
                 goal_handle.canceled()
                 return SortByCharacterFrequency.Result()
 
@@ -55,10 +58,10 @@ class MinimalAction(Node):
 
             # Update our progress
             feedback_msg.progress = float(i) / float(len(input))
-            self.get_logger().info('Feedback: %f' % feedback_msg.progress)
+            self.get_logger().info("Feedback: %f" % feedback_msg.progress)
             goal_handle.publish_feedback(feedback_msg)
 
-            # Sleep (to simulate the delay that a robot might have during a 
+            # Sleep (to simulate the delay that a robot might have during a
             # ROS action)
             time.sleep(self.sleep_time)
 
@@ -66,7 +69,9 @@ class MinimalAction(Node):
 
         result = SortByCharacterFrequency.Result()
         uniqueLetters = "".join(character_frequency.keys())
-        result.result = "".join(sorted(uniqueLetters, key=lambda x: character_frequency[x], reverse=True))
+        result.result = "".join(
+            sorted(uniqueLetters, key=lambda x: character_frequency[x], reverse=True)
+        )
         return result
 
 
@@ -81,5 +86,5 @@ def main(args=None):
     rclpy.spin(minimal_action, executor=executor)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/feeding_web_app_ros2_test/feeding_web_app_ros2_test/subscriber.py
+++ b/feeding_web_app_ros2_test/feeding_web_app_ros2_test/subscriber.py
@@ -6,14 +6,11 @@ from std_msgs.msg import String
 
 
 class MinimalSubscriber(Node):
-
     def __init__(self):
-        super().__init__('minimal_subscriber')
+        super().__init__("minimal_subscriber")
         self.subscription = self.create_subscription(
-            String,
-            'test_topic',
-            self.listener_callback,
-            10)
+            String, "test_topic", self.listener_callback, 10
+        )
         self.subscription  # prevent unused variable warning
 
     def listener_callback(self, msg):
@@ -34,5 +31,5 @@ def main(args=None):
     rclpy.shutdown()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/feeding_web_app_ros2_test/setup.py
+++ b/feeding_web_app_ros2_test/setup.py
@@ -1,29 +1,28 @@
 from setuptools import setup
 
-package_name = 'feeding_web_app_ros2_test'
+package_name = "feeding_web_app_ros2_test"
 
 setup(
     name=package_name,
-    version='0.0.0',
+    version="0.0.0",
     packages=[package_name],
     data_files=[
-        ('share/ament_index/resource_index/packages',
-            ['resource/' + package_name]),
-        ('share/' + package_name, ['package.xml']),
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
     ],
-    install_requires=['setuptools'],
+    install_requires=["setuptools"],
     zip_safe=True,
-    maintainer='Amal Nanavati',
-    maintainer_email='amaln@cs.washington.edu',
-    description='A minimal ROS publisher, subscriber, service, and action to use to test the web app.',
-    license='TODO: License declaration',
-    tests_require=['pytest'],
+    maintainer="Amal Nanavati",
+    maintainer_email="amaln@cs.washington.edu",
+    description="A minimal ROS publisher, subscriber, service, and action to use to test the web app.",
+    license="TODO: License declaration",
+    tests_require=["pytest"],
     entry_points={
-        'console_scripts': [
-                'listener = feeding_web_app_ros2_test.subscriber:main',
-                'reverse_string = feeding_web_app_ros2_test.reverse_string_service:main',
-                'sort_by_character_frequency = feeding_web_app_ros2_test.sort_by_character_frequency_action:main',
-                'talker = feeding_web_app_ros2_test.publisher:main',
+        "console_scripts": [
+            "listener = feeding_web_app_ros2_test.subscriber:main",
+            "reverse_string = feeding_web_app_ros2_test.reverse_string_service:main",
+            "sort_by_character_frequency = feeding_web_app_ros2_test.sort_by_character_frequency_action:main",
+            "talker = feeding_web_app_ros2_test.publisher:main",
         ],
-},
+    },
 )

--- a/feeding_web_app_ros2_test/test/test_copyright.py
+++ b/feeding_web_app_ros2_test/test/test_copyright.py
@@ -17,9 +17,11 @@ import pytest
 
 
 # Remove the `skip` decorator once the source file(s) have a copyright header
-@pytest.mark.skip(reason='No copyright header has been placed in the generated source file.')
+@pytest.mark.skip(
+    reason="No copyright header has been placed in the generated source file."
+)
 @pytest.mark.copyright
 @pytest.mark.linter
 def test_copyright():
-    rc = main(argv=['.', 'test'])
-    assert rc == 0, 'Found errors'
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found errors"

--- a/feeding_web_app_ros2_test/test/test_flake8.py
+++ b/feeding_web_app_ros2_test/test/test_flake8.py
@@ -20,6 +20,6 @@ import pytest
 @pytest.mark.linter
 def test_flake8():
     rc, errors = main_with_errors(argv=[])
-    assert rc == 0, \
-        'Found %d code style errors / warnings:\n' % len(errors) + \
-        '\n'.join(errors)
+    assert rc == 0, "Found %d code style errors / warnings:\n" % len(
+        errors
+    ) + "\n".join(errors)

--- a/feeding_web_app_ros2_test/test/test_pep257.py
+++ b/feeding_web_app_ros2_test/test/test_pep257.py
@@ -19,5 +19,5 @@ import pytest
 @pytest.mark.linter
 @pytest.mark.pep257
 def test_pep257():
-    rc = main(argv=['.', 'test'])
-    assert rc == 0, 'Found code style errors / warnings'
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found code style errors / warnings"


### PR DESCRIPTION
[Describe this pull request. Link to relevant GitHub issues, if any.]

As always, it is best practice to have a consistent format in code. The [black formatter](https://black.readthedocs.io/en/stable/) is a commonly used and effective formatter for Python code. This PR runs all Python files in this repository through the black formatter.

Eventually, we will want to make black formatting an explicit part of the process and CI. #32 is about that.

[Explain how this pull request was tested, including but not limited to the below checkmarks.]

No need for tests, all changes are aesthetic. I first installed black (`pip install black`), navigated to the `feeding_web_interface` directory, and ran `python3 -m black .` to reformat all Python files in the directory.

***

**Before creating a pull request**

- [N/A] Format code with `npm run format`
- [N/A] Thoroughly test your code's functionality, including unintended uses.
- [N/A] Thoroughly test your code's responsiveness by rendering it on different devices, browsers, etc.
- [N/A] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [x] Squash all your commits into one (or `Squash and Merge`)
