### PR TITLE
Create Dummy ROS2 Nodes for MoveAbovePlate, Integrates into App

### DIFF
--- a/feeding_web_app_ros2_msgs/package.xml
+++ b/feeding_web_app_ros2_msgs/package.xml
@@ -5,7 +5,7 @@
   <version>0.0.0</version>
   <description>Defines the message types used by `feeding_web_app_ros2_test`.</description>
   <maintainer email="amaln@cs.washington.edu">Amal Nanavati</maintainer>
-  <license>TODO: License declaration</license>
+  <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/feeding_web_app_ros2_test/feeding_web_app_ros2_test/MoveAbovePlate.py
+++ b/feeding_web_app_ros2_test/feeding_web_app_ros2_test/MoveAbovePlate.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from ada_feeding_msgs.action import MoveTo
+from feeding_web_app_ros2_test.MoveToDummy import MoveToDummy
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    move_above_plate = MoveToDummy("MoveAbovePlate", MoveTo)
+
+    # Use a MultiThreadedExecutor to enable processing goals concurrently
+    executor = MultiThreadedExecutor()
+
+    rclpy.spin(move_above_plate, executor=executor)
+
+
+if __name__ == "__main__":
+    main()

--- a/feeding_web_app_ros2_test/feeding_web_app_ros2_test/MoveToDummy.py
+++ b/feeding_web_app_ros2_test/feeding_web_app_ros2_test/MoveToDummy.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+import rclpy
+from rclpy.action import ActionServer, CancelResponse, GoalResponse
+from rclpy.node import Node
+import threading
+import time
+
+
+class MoveToDummy(Node):
+    def __init__(
+        self,
+        name,
+        action_class,
+        send_feedback_hz=10,
+        dummy_plan_time=2.5,
+        dummy_motion_time=10.0,
+    ):
+        """
+        Initialize the MoveToDummy action node.
+
+        Parameters
+        ----------
+        name: The name of the action server.
+        action_class: The action class to use for the action server.
+        send_feedback_hz: The target frequency at which to send feedback.
+        dummy_plan_time: How many seconds this dummy node should spend in planning.
+        dummy_motion_time: How many seconds this dummy node should spend in motion.
+        """
+        super().__init__(name)
+
+        self.send_feedback_hz = send_feedback_hz
+        self.dummy_plan_time = dummy_plan_time
+        self.dummy_motion_time = dummy_motion_time
+        self.action_class = action_class
+
+        self.active_goal_request = None
+
+        self._action_server = ActionServer(
+            self,
+            action_class,
+            name,
+            self.execute_callback,
+            goal_callback=self.goal_callback,
+            cancel_callback=self.cancel_callback,
+        )
+
+    def goal_callback(self, goal_request):
+        """
+        Accept a goal if this action does not already have an active goal,
+        else reject.
+
+        Parameters
+        ----------
+        goal_request: The goal request message.
+        """
+        self.get_logger().info("Received goal request")
+        if self.active_goal_request is None:
+            self.get_logger().info("Accepting goal request")
+            self.active_goal_request = goal_request
+            return GoalResponse.ACCEPT
+        self.get_logger().info("Rejecting goal request")
+        return GoalResponse.REJECT
+
+    def cancel_callback(self, goal_handle):
+        """
+        Always accept client requests to cancel the active goal. Note that this
+        function should not actually impelement the cancel; that is handled in
+        `execute_callback`
+
+        Parameters
+        ----------
+        goal_handle: The goal handle.
+        """
+        self.get_logger().info("Received cancel request, accepting")
+        return CancelResponse.ACCEPT
+
+    def plan(self, plan, success):
+        """
+        A dummy thread for planning to the target position. This thread
+        will sleep for `self.dummy_plan_time` sec and then set the plan to None.
+
+        Parameters
+        ----------
+        plan: A mutable object, which will contain the plan once the thread has
+              finished. For this dummy thread, it contains None.
+        success: A mutable object, which will contain the success status once
+                 the thread has finished.
+        """
+        time.sleep(self.dummy_plan_time)
+        plan.append(None)
+        success[0] = True
+
+    def move(self, plan, success):
+        """
+        A dummy thread for moving the robot arm along the plan. This thread
+        will sleep for `self.dummy_motion_time` sec and then return success.
+
+        Parameters
+        ----------
+        plan: Contains the plan.
+        success: A mutable object, which will contain the success status once
+                 the thread has finished.
+        """
+        time.sleep(self.dummy_motion_time)
+        success[0] = True
+
+    async def execute_callback(self, goal_handle):
+        """
+        First, plan to the target position. Then, move to that position.
+        As a "dummy node," this specific node will spend `self.dummy_plan_time`
+        sec in planning and `self.dummy_motion_time` sec in motion.
+
+        NOTE: In the actual (not dummy) implementation, we will be calling a
+        ROS action defined by MoveIt to do both planning and execution. Because
+        actions are non-blocking, we won't need to break off separate threads.
+        Using separate threads is an artiface of using time.sleep() in this
+        dummy implementation.
+        """
+        self.get_logger().info("Executing goal...%s" % (goal_handle,))
+
+        # Load the feedback parameters
+        feedback_rate = self.create_rate(self.send_feedback_hz)
+        feedback_msg = self.action_class.Feedback()
+
+        # Start the planning thread
+        plan = []
+        plan_success = [False]
+        planning_thread = threading.Thread(
+            target=self.plan, args=(plan, plan_success), daemon=True
+        )
+        planning_thread.start()
+        planning_start_time = self.get_clock().now()
+        is_planning = True
+
+        # Create (but don't yet start) the motion thread
+        is_moving = False
+        motion_success = [False]
+        motion_thread = threading.Thread(
+            target=self.move, args=(plan, motion_success), daemon=True
+        )
+
+        # Monitor the planning and motion threads, and send feedback
+        while rclpy.ok() and (is_planning or is_moving):
+            # Check if there is a cancel request
+            if goal_handle.is_cancel_requested:
+                self.get_logger().info("Goal canceled")
+                goal_handle.canceled()
+                result = self.action_class.Result()
+                result.status = result.STATUS_CANCELED
+                self.active_goal_request = None  # Clear the active goal
+                return result
+
+            # Check if the planning thread has finished
+            if is_planning:
+                if not planning_thread.is_alive():
+                    is_planning = False
+                    if plan_success[0]:  # Plan succeeded
+                        self.get_logger().info(
+                            "Planning succeeded, proceeding to motion"
+                        )
+                        # Start the motion thread
+                        motion_thread.start()
+                        motion_start_time = self.get_clock().now()
+                        is_moving = True
+                        continue
+                    else:  # Plan failed
+                        self.get_logger().info("Planning failed, aborting")
+                        # Abort the goal
+                        goal_handle.abort()
+                        result = self.action_class.Result()
+                        result.status = result.STATUS_PLANNING_FAILED
+                        self.active_goal_request = None  # Clear the active goal
+                        return result
+
+            # Check if the motion thread has finished
+            if is_moving:
+                if not motion_thread.is_alive():
+                    is_moving = False
+                    if motion_success[0]:
+                        self.get_logger().info("Motion succeeded, returning")
+                        # Succeed the goal
+                        goal_handle.succeed()
+                        result = self.action_class.Result()
+                        result.status = result.STATUS_SUCCESS
+                        self.active_goal_request = None  # Clear the active goal
+                        return result
+                    else:
+                        self.get_logger().info("Motion failed, aborting")
+                        # Abort the goal
+                        goal_handle.abort()
+                        result = self.action_class.Result()
+                        result.status = result.STATUS_MOTION_FAILED
+                        self.active_goal_request = None  # Clear the active goal
+                        return result
+
+            # Send feedback
+            feedback_msg.is_planning = is_planning
+            if is_planning:
+                feedback_msg.planning_time = (
+                    self.get_clock().now() - planning_start_time
+                ).to_msg()
+            elif is_moving:
+                # TODO: In the actual (not dummy) implementation, this should
+                # return the distance (not time) the robot has yet to move.
+                feedback_msg.motion_initial_distance = self.dummy_motion_time
+                elapsed_time = self.get_clock().now() - motion_start_time
+                elapsed_time_float = elapsed_time.nanoseconds / 1.0e9
+                feedback_msg.motion_curr_distance = (
+                    self.dummy_motion_time - elapsed_time_float
+                )
+            self.get_logger().info("Feedback: %s" % feedback_msg)
+            goal_handle.publish_feedback(feedback_msg)
+
+            # Sleep for the specified feedback rate
+            feedback_rate.sleep()
+
+        # If we get here, something went wrong
+        self.get_logger().info("Unknown error, aborting")
+        goal_handle.abort()
+        result = self.action_class.Result()
+        result.status = result.STATUS_UNKNOWN
+        self.active_goal_request = None  # Clear the active goal
+        return result

--- a/feeding_web_app_ros2_test/package.xml
+++ b/feeding_web_app_ros2_test/package.xml
@@ -5,7 +5,7 @@
   <version>0.0.0</version>
   <description>A minimal ROS publisher, subscriber, service, and action to use to test the web app.</description>
   <maintainer email="amaln@cs.washington.edu">Amal Nanavati</maintainer>
-  <license>TODO: License declaration</license>
+  <license>BSD-3-Clause</license>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/feeding_web_app_ros2_test/setup.py
+++ b/feeding_web_app_ros2_test/setup.py
@@ -15,10 +15,13 @@ setup(
     maintainer="Amal Nanavati",
     maintainer_email="amaln@cs.washington.edu",
     description="A minimal ROS publisher, subscriber, service, and action to use to test the web app.",
-    license="TODO: License declaration",
+    license="BSD-3-Clause",
     tests_require=["pytest"],
     entry_points={
         "console_scripts": [
+            # Scripts for the main app
+            "MoveAbovePlate = feeding_web_app_ros2_test.MoveAbovePlate:main",
+            # Scripts for the "TestROS" component
             "listener = feeding_web_app_ros2_test.subscriber:main",
             "reverse_string = feeding_web_app_ros2_test.reverse_string_service:main",
             "sort_by_character_frequency = feeding_web_app_ros2_test.sort_by_character_frequency_action:main",

--- a/feedingwebapp/README.md
+++ b/feedingwebapp/README.md
@@ -14,6 +14,7 @@ The overall user flow for this robot can be seen below.
 - [Node.js](https://nodejs.org/en/download/package-manager)
 - [ROS2 Humble](https://docs.ros.org/en/humble/Installation.html)
 - [PRL fork of rosbridge_suite](https://github.com/personalrobotics/rosbridge_suite). This fork enables rosbridge_suite to communicate with ROS2 actions.
+- [ada_feeding (branch: ros2-devel)](https://github.com/personalrobotics/ada_feeding/tree/ros2-devel).
 
 ## Getting Started in Computer
 
@@ -31,14 +32,29 @@ The overall user flow for this robot can be seen below.
   - Note that if you're not running the robot code alongside the app, set [`debug = true` in `App.jsx`](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp/src/App.jsx#L17) to be able to move past screens where the app is waiting on the robot. Since the robot is not yet connected, the default is `debug = true`
 3. Use a web browser to navigate to `localhost:3000` to see the application.
 
+#### Launching Dummy Nodes
+This repository includes several dummy nodes that match the interface that the robot nodes will use. By running the dummy nodes alongside the app, we can test the app's communication with the robot even without actual robot code running.
+
+The below instructions are for `MoveAbovePlate`; we will add to the instructions as more dummy nodes get implemented.
+1. Navigate to your ROS2 workspace: `cd {path/to/your/ros2/workspace}`
+2. Build your workspace: `colcon build`
+3. Launch rosbridge: `source install/setup.bash; ros2 launch rosbridge_server rosbridge_websocket_launch.xml`
+4. In another terminal, run the MoveAbovePlate action: `source install/setup.bash; ros2 run feeding_web_app_ros2_test MoveAbovePlate`
+5. In another terminal, navigate to the web app folder: `cd {path/to/feeding_web_interface}/feedingwebapp`
+6. Start the app: `npm start`
+7. Use a web browser to navigate to `localhost:3000`.
+
+You should now see that the web browser is connected to ROS. Further, you should see that when the `MoveAbovePlate` page starts, it should call the action (exactly once), and render feedback. "Pause" should cancel the action, and "Resume" should re-call it. Refreshing the page should cancel the action. When the action returns success, the app should automatically transition to the next page.
+
 ### Usage (Test ROS)
 There is a special page in the app intended for developers to: (a) test that their setup of the app and ROS2 enables the two to communicate as expected; and (b) gain familiarity with the library of ROS helper functions we use in the web app (see [TechDocumentation.md](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp/TechDocumentation.md)). Below are instructions to use this page:
 1. Navigate to your ROS2 workspace: `cd {path/to/your/ros2/workspace}`
 2. Build your workspace: `colcon build`
-3. Launch rosbridge: `ros2 launch rosbridge_server rosbridge_websocket_launch.xml`
-4. In another terminal, navigate to the web app folder: `cd {path/to/feeding_web_interface}/feedingwebapp`
-5. Start the app: `npm start`
-6. Use a web browser to navigate to `localhost:3000/test_ros`.
+3. Source your workspace: `source install/setup.bash`
+4. Launch rosbridge: `ros2 launch rosbridge_server rosbridge_websocket_launch.xml`
+5. In another terminal, navigate to the web app folder: `cd {path/to/feeding_web_interface}/feedingwebapp`
+6. Start the app: `npm start`
+7. Use a web browser to navigate to `localhost:3000/test_ros`.
 
 The following are checks to ensure the app is interacting with ROS as expected. If any of them fails, you'll have to do additional troubleshooting to get the web app and ROS2 smoothly communicating with each other.
 1. First, check if the page says `Connected` at the top of the screen. If not, the web app is not communicating with ROS2.

--- a/feedingwebapp/TechDocumentation.md
+++ b/feedingwebapp/TechDocumentation.md
@@ -19,6 +19,14 @@ All functions to interact with ROS are defined in [`ros_helpers.jsx`](https://gi
 
 Although the web app's settings menu seem parameter-esque it is not a good idea to update settings by getting/setting ROS parameters. That is because ROS2 parameters are owned by individual nodes, and do not persist beyond the lifetime of a node. Further, we likely want to run downstream code after updating any setting (e.g., writing it to a file as backup), which cannot easily be done when setting ROS parameters. Therefore, **updating settings should be done by ROS service calls, not by getting/setting ROS parameters**. Hence, `ros_helpers.jsx` does not even implement parameter getting/setting.
 
+### Using ROS Services, Actions, etc. Within React
+
+React, by default, will re-render a component any time local state changes. In other words, it will re-run all code in the function that defines that component. However, this doesn't work well for ROS Services, Actions, etc. because: (a) we don't want to keep re-calling the service/action each time the UI re-renders; and (b) we don't want to keep re-creating a service/action client each time the UI re-renders. Therefore, it is crucial to use React Hooks intentionally and to double and triple check that the service/action is only getting once, to avoid bugs.
+
+These resources that can help you understand React Hooks in general:
+- https://medium.com/@guptagaruda/react-hooks-understanding-component-re-renders-9708ddee9928
+- https://stackoverflow.com/a/69264685
+
 ## Frequently Asked Questions (FAQ)
 
 Q: Why are we using global state as opposed to a [`Router`](https://www.w3schools.com/react/react_router.asp) to decide which app components to render?

--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -1,4 +1,5 @@
 import { MEAL_STATE } from './GlobalState'
+
 // The RealSense's default video stream is 640x480
 export const REALSENSE_WIDTH = 640
 export const REALSENSE_HEIGHT = 480
@@ -21,3 +22,28 @@ FOOTER_STATE_ICON_DICT[MEAL_STATE.R_MovingToStagingLocation] = '/robot_state_img
 FOOTER_STATE_ICON_DICT[MEAL_STATE.R_MovingToMouth] = '/robot_state_imgs/move_to_mouth_position.svg'
 FOOTER_STATE_ICON_DICT[MEAL_STATE.R_StowingArm] = '/robot_state_imgs/stowing_arm_position.svg'
 export { FOOTER_STATE_ICON_DICT }
+
+// For states that call ROS actions, this dictionary contains
+// the action name and the message type
+let ROS_ACTIONS_NAMES = {}
+ROS_ACTIONS_NAMES[MEAL_STATE.R_MovingAbovePlate] = {
+  actionName: 'MoveAbovePlate',
+  messageType: 'ada_feeding_msgs/action/MoveTo'
+}
+export { ROS_ACTIONS_NAMES }
+
+// The meaning of the status that motion actions return in their results.
+// These should match the action definition(s)
+export const MOTION_STATUS_SUCCESS = 0
+export const MOTION_STATUS_PLANNING_FAILED = 1
+export const MOTION_STATUS_MOTION_FAILED = 2
+export const MOTION_STATUS_CANCELED = 3
+export const MOTION_STATUS_UNKNOWN = 99
+
+// The meaning of ROS Action statuses.
+// https://docs.ros2.org/latest/api/rclpy/api/actions.html#rclpy.action.server.GoalEvent
+export const ROS_ACTION_STATUS_EXECUTE = '1'
+export const ROS_ACTION_STATUS_CANCEL_GOAL = '2'
+export const ROS_ACTION_STATUS_SUCCEED = '3'
+export const ROS_ACTION_STATUS_ABORT = '4'
+export const ROS_ACTION_STATUS_CANCELED = '5'

--- a/feedingwebapp/src/Pages/Footer/Footer.jsx
+++ b/feedingwebapp/src/Pages/Footer/Footer.jsx
@@ -1,108 +1,72 @@
 // React imports
-import React, { useState } from 'react'
+import React, { useCallback } from 'react'
 import { MDBFooter } from 'mdb-react-ui-kit'
 import Button from 'react-bootstrap/Button'
 import { View } from 'react-native'
 import Row from 'react-bootstrap/Row'
+// PropTypes is used to validate that the used props are in fact passed to this
+// Component
+import PropTypes from 'prop-types'
 
 // Local imports
 import { FOOTER_STATE_ICON_DICT } from '../Constants'
-import { useGlobalState, MEAL_STATE } from '../GlobalState'
+import { useGlobalState } from '../GlobalState'
 
 /**
  * The Footer shows a pause button. When users click it, the app tells the robot
  * to immediately pause and displays a back button that allows them to return to
  * previous state and a resume button that allows them to resume current state.
  */
-const Footer = () => {
-  // Set the current meal state
-  const setMealState = useGlobalState((state) => state.setMealState)
+const Footer = (props) => {
   // Get the current meal state
   const mealState = useGlobalState((state) => state.mealState)
-  /**
-   * Regardless of the state, the back button should revert to MoveAbovePlate.
-   *   - BiteAcquisition: In this case, pressing "back" should let the user
-   *     reselect the bite, which requires the robot to move above plate.
-   *   - MoveToStagingLocation: In this case, pressing "back" should move the
-   *     robot back to the plate. Although the user may not always want to
-   *     reselect the bite, from `BiteSelection` they have the option to skip
-   *     BiteAcquisition and move straight to staging location (when they are ready).
-   *   - MoveToMouth: Although in some cases the user may want "back" to move to
-   *     the staging location, since we will be removing the staging location
-   *     (Issue #45) it makes most sense to move the robot back to the plate.
-   *   - StowingArm: In this case, if the user presses back they likely want to
-   *     eat another bite, hence moving above the plate makes sense.
-   *   - MovingAbovePlate: Although the user may want to press "back" to move
-   *     the robot to the staging location, they can also go forward to
-   *     BiteSelection and then move the robot to the staging location.
-   *     Hence, in this case we don't have a "back" button.
-   */
-  // A local variable for storing back icon image
-  var backIcon = FOOTER_STATE_ICON_DICT[MEAL_STATE.R_MovingAbovePlate]
-  // A local variable for storing current state icon image
-  var resumeIcon = FOOTER_STATE_ICON_DICT[mealState]
-  // Local state variable to track of visibility of pause button
-  const [pauseButtonVisible, setPauseButtonVisible] = useState(true)
-  // Local state variable to track of visibility of back button
-  const [backButtonVisible, setBackButtonVisible] = useState(false)
-  // Local state variable to track of visibility of resume button
-  const [resumeButtonVisible, setResumeButtonVisible] = useState(false)
-  // width of Back and Resume buttons
+
+  // Icons and other parameters for the footer buttons
+  let pauseIcon = '/robot_state_imgs/pause_button_icon.svg'
+  let backIcon = props.backMealState ? FOOTER_STATE_ICON_DICT[props.backMealState] : ''
+  let resumeIcon = FOOTER_STATE_ICON_DICT[mealState]
+  let phantomButtonIcon = '/robot_state_imgs/phantom_view_image.svg'
+  // Width of Back and Resume buttons
   let backResumeButtonWidth = '150px'
-  // height of all Footer buttons
+  // Height of all Footer buttons
   let footerButtonHight = '100px'
+  /**
+   * When the pause button is clicked, execute the callback and display the
+   * back and resume buttons.
+   */
+  const pauseClicked = useCallback(() => {
+    props.pauseCallback()
+    props.setPaused(true)
+  }, [])
 
   /**
-   * When the pause button is clicked, show back and/or resume buttons.
+   * When the resume button is clicked, execute the callback and display the
+   * pause button.
    */
-  function pauseButtonClicked() {
-    /**  We call setPauseButtonVisible, setBackButtonVisible, and setResumeButtonVisible
-     * with new values to make pause button invisible and resume and/or back button visible.
-     * React will re-render the Footer component.
-     */
-    setPauseButtonVisible(false)
-    if (mealState === MEAL_STATE.R_BiteAcquisition) {
-      setBackButtonVisible(true)
-    } else if (mealState === MEAL_STATE.R_MovingAbovePlate) {
-      setResumeButtonVisible(true)
-    } else {
-      setBackButtonVisible(true)
-      setResumeButtonVisible(true)
+  const resumeClicked = useCallback(() => {
+    if (props.resumeCallback) {
+      props.resumeCallback()
     }
-  }
+    props.setPaused(false)
+  }, [])
 
   /**
-   * When the resume button is clicked, continue with the current meal state.
+   * When the back button is clicked, execute the callback and display the pause
+   * button.
    */
-  function resumeButtonClicked() {
-    /**  We call setPauseButtonVisible, setBackButtonVisible, and setResumeButtonVisible
-     * with new values to make pause button visible again.
-     * React will re-render the Footer component.
-     */
-    setPauseButtonVisible(true)
-    setBackButtonVisible(false)
-    setResumeButtonVisible(false)
-  }
-
-  /**
-   * When the back button is clicked, go back to previous state.
-   */
-  function backButtonClicked() {
-    // Set meal state to move above plate
-    setMealState(MEAL_STATE.R_MovingAbovePlate)
-    /**  We call setPauseButtonVisible, setBackButtonVisible, and setResumeButtonVisible
-     * with new values to make pause button visible again.
-     * React will re-render the Footer component.
-     */
-    resumeButtonClicked()
-  }
+  const backClicked = useCallback(() => {
+    if (props.backCallback) {
+      props.backCallback()
+    }
+    props.setPaused(false)
+  }, [])
 
   /**
    * Get the pause text and button to render in footer.
    *
    * @returns {JSX.Element} the pause text and button
    */
-  let pauseTextAndButton = function () {
+  const renderPauseButton = useCallback(() => {
     return (
       <>
         <Row className='justify-content-center mx-auto'>
@@ -112,27 +76,22 @@ const Footer = () => {
           {/* Icon to pause */}
           <Button
             variant='danger'
-            onClick={pauseButtonClicked}
+            onClick={pauseClicked}
             style={{ marginLeft: '10', marginRight: '10', marginTop: '0', width: '350px', height: { footerButtonHight } }}
           >
-            <img
-              style={{ width: '135px', height: '90px' }}
-              src='/robot_state_imgs/pause_button_icon.svg'
-              alt='pause_icon_img'
-              className='center'
-            />
+            <img style={{ width: '135px', height: '90px' }} src={pauseIcon} alt='pause_icon' className='center' />
           </Button>
         </Row>
       </>
     )
-  }
+  }, [pauseClicked])
 
   /**
    * Get the back text and button to render in footer.
    *
    * @returns {JSX.Element} the back text and button
    */
-  let backTextAndButton = function () {
+  const renderBackButton = useCallback(() => {
     return (
       <>
         <p className='transitionMessage' style={{ marginBottom: '0', fontSize: '170%', color: 'white', fontWeight: 'bold' }}>
@@ -141,21 +100,21 @@ const Footer = () => {
         {/* Icon to move to previous state */}
         <Button
           variant='warning'
-          onClick={backButtonClicked}
+          onClick={backClicked}
           style={{ marginLeft: 10, marginRight: 10, width: { backResumeButtonWidth }, height: { footerButtonHight } }}
         >
-          <img style={{ width: '120px', height: '72px' }} src={backIcon} alt='back_icon_img' className='center' />
+          <img style={{ width: '120px', height: '72px' }} src={backIcon} alt='back_icon' className='center' />
         </Button>
       </>
     )
-  }
+  }, [backClicked])
 
   /**
    * Get the resume text and button to render in footer.
    *
    * @returns {JSX.Element} the resume text and button
    */
-  let resumeTextAndButton = function () {
+  const renderResumeButton = useCallback(() => {
     return (
       <>
         <p
@@ -167,26 +126,27 @@ const Footer = () => {
         {/* Icon to resume current state */}
         <Button
           variant='success'
-          onClick={resumeButtonClicked}
+          onClick={resumeClicked}
           style={{ marginLeft: 10, marginRight: 10, width: { backResumeButtonWidth }, height: { footerButtonHight } }}
         >
-          <img style={{ width: '120px', height: '72px' }} src={resumeIcon} alt='resume_icon_img' className='center' />
+          <img style={{ width: '120px', height: '72px' }} src={resumeIcon} alt='resume_icon' className='center' />
         </Button>
       </>
     )
-  }
+  }, [resumeClicked])
 
   /**
-   * Get the phantom view to render in footer.
+   * Get the phantom view to render in footer. This is used as a placeholder
+   * when the back button or resume button are disabled.
    *
    * @returns {JSX.Element} the phantom view
    */
-  let phantomView = function () {
+  let renderPhantomButton = function () {
     return (
       <>
         <Button
           variant='ghost'
-          disabled='true'
+          disabled={true}
           style={{
             backgroundColor: 'transparent',
             border: 'none',
@@ -196,12 +156,7 @@ const Footer = () => {
             height: { footerButtonHight }
           }}
         >
-          <img
-            style={{ width: '120px', height: '72px' }}
-            src='/robot_state_imgs/phantom_view_image.svg'
-            alt='phantom_button_img'
-            className='center'
-          />
+          <img style={{ width: '120px', height: '72px' }} src={phantomButtonIcon} alt='phantom_button_img' className='center' />
         </Button>
       </>
     )
@@ -210,41 +165,29 @@ const Footer = () => {
   // Render the component
   return (
     <>
-      {/**
-       * The footer shows a pause button first. A resume button and/or
-       * a back button are shown when the pause button is clicked.
-       *
-       * -  If the pause button is visible, regardless of the meal state
-       *    show a pause button taking the whole width of the footer screen.
-       *
-       * -  In Move Above Plate state, if pause button is not visible,
-       *    only show the resume button and no back button, since the user
-       *    can go "forward" to any other state as opposed to going back.
-       *
-       * -  In Bite Acquisition state, if pause button is not visible,
-       *    only show the back button and no resume button, since the user
-       *    can continue to acquiring bite again after moving above plate,
-       *    but if they resume this state after aquiring bite, bite selection
-       *    mask may no longer work because the food may have shifted
-       *
-       * -  For any other meal state (e.g., MoveToStagingLocation, MoveToMouth,
-       *    and StowingArm), if the pause button is not visible, then the footer
-       *    shows both the back and resume buttons
-       */}
       <MDBFooter bgColor='dark' className='text-center text-lg-left fixed-bottom'>
         <div className='text-center p-3' style={{ backgroundColor: 'rgba(0, 0, 0, 0.2)' }}>
-          {pauseButtonVisible ? (
-            pauseTextAndButton()
-          ) : (
+          {props.paused ? (
             <View style={{ flexDirection: 'row', justifyContent: 'center' }}>
-              <View>{backButtonVisible ? backTextAndButton() : phantomView()}</View>
-              <View>{resumeButtonVisible ? resumeTextAndButton() : phantomView()}</View>
+              <View>{props.backCallback && props.backMealState ? renderBackButton() : renderPhantomButton()}</View>
+              <View>{props.resumeCallback ? renderResumeButton() : renderPhantomButton()}</View>
             </View>
+          ) : (
+            renderPauseButton()
           )}
         </div>
       </MDBFooter>
     </>
   )
+}
+Footer.propTypes = {
+  paused: PropTypes.bool.isRequired,
+  setPaused: PropTypes.func.isRequired,
+  pauseCallback: PropTypes.func.isRequired,
+  // If any of the below three are null, the Footer won't render that button
+  resumeCallback: PropTypes.func,
+  backCallback: PropTypes.func,
+  backMealState: PropTypes.string
 }
 
 export default Footer

--- a/feedingwebapp/src/Pages/Home/MealStates/BiteAcquisition.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/BiteAcquisition.jsx
@@ -1,5 +1,5 @@
 // React Imports
-import React from 'react'
+import React, { useState } from 'react'
 import Button from 'react-bootstrap/Button'
 // PropTypes is used to validate that the used props are in fact passed to this
 // Component
@@ -19,6 +19,9 @@ import { useGlobalState, MEAL_STATE } from '../../GlobalState'
  * @params {object} props - contains any properties passed to this Component
  */
 const BiteAcquisition = (props) => {
+  // Create a local state variable for whether the robot is paused.
+  const [paused, setPaused] = useState(false)
+
   // Get the relevant global variables
   const setMealState = useGlobalState((state) => state.setMealState)
   const desiredFoodItem = useGlobalState((state) => state.desiredFoodItem)
@@ -29,6 +32,15 @@ const BiteAcquisition = (props) => {
   function biteAcquisitionDone() {
     console.log('biteAcquisitionDone')
     setMealState(MEAL_STATE.U_BiteAcquisitionCheck)
+  }
+
+  /**
+   * Callback function for when the back button is clicked.
+   */
+  const backMealState = MEAL_STATE.R_MovingAbovePlate
+  function backCallback() {
+    console.log('Back Clicked')
+    setMealState(backMealState)
   }
 
   // Render the component
@@ -50,14 +62,23 @@ const BiteAcquisition = (props) => {
         </div>
       </Row>
       {/**
-       * Display the footer with the Pause button.
+       * Display the footer with the Pause button. BiteAcquisition has no resume
+       * button, because the selected food mask may no longer be usable (e.g.,
+       * if the robot moved the food items)
        */}
-      <Footer />
+      <Footer
+        pauseCallback={() => console.log('Pause Clicked')}
+        backCallback={backCallback}
+        backMealState={backMealState}
+        resumeCallback={null}
+        paused={paused}
+        setPaused={setPaused}
+      />
     </>
   )
 }
 BiteAcquisition.propTypes = {
-  debug: PropTypes.bool
+  debug: PropTypes.bool.isRequired
 }
 
 export default BiteAcquisition

--- a/feedingwebapp/src/Pages/Home/MealStates/MovingAbovePlate.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/MovingAbovePlate.jsx
@@ -1,5 +1,5 @@
 // React Imports
-import React from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 import Button from 'react-bootstrap/Button'
 // PropTypes is used to validate that the used props are in fact passed to this
 // Component
@@ -7,9 +7,19 @@ import PropTypes from 'prop-types'
 import Row from 'react-bootstrap/Row'
 
 // Local Imports
+import { connectToROS, createROSActionClient, callROSAction, cancelROSAction, destroyActionClient } from '../../../ros/ros_helpers'
 import Footer from '../../Footer/Footer'
 import '../Home.css'
 import { useGlobalState, MEAL_STATE } from '../../GlobalState'
+import {
+  ROS_ACTIONS_NAMES,
+  MOTION_STATUS_SUCCESS,
+  ROS_ACTION_STATUS_CANCEL_GOAL,
+  ROS_ACTION_STATUS_EXECUTE,
+  ROS_ACTION_STATUS_SUCCEED,
+  ROS_ACTION_STATUS_ABORT,
+  ROS_ACTION_STATUS_CANCELED
+} from '../../Constants'
 
 /**
  * The MovingAbovePlate component tells the user that the robot is currently
@@ -22,12 +32,186 @@ const MovingAbovePlate = (props) => {
   // Get the relevant global variables
   const setMealState = useGlobalState((state) => state.setMealState)
 
+  // Create a local state variable for whether the robot is paused and another
+  // to store the status of the action
+  const [paused, setPaused] = useState(false)
+  // NOTE: We slightly abuse the ROS_ACTION_STATUS values in this local state
+  // variable, by using it as a proxy for whether the robot is executing, has
+  // succeeded, has been canceled, or has had an error. This is to avoid
+  // creating an extra enum.
+  const [actionStatus, setActionStatus] = useState({
+    actionStatus: null
+  })
+
+  // Connect to ROS, if not already connected. Put this in local state to avoid
+  // re-connecting upon every re-render.
+  const ros = useState(connectToROS().ros)[0]
+
+  // Create the ROS Action Client. This is created in local state to avoid
+  // re-creating it upon every re-render.
+  let { actionName, messageType } = ROS_ACTIONS_NAMES[MEAL_STATE.R_MovingAbovePlate]
+  let moveAbovePlateAction = useState(createROSActionClient(ros, actionName, messageType))[0]
+
+  /**
+   * Callback function for when the action sends feedback. It updates the
+   * actionStatus local state variable.
+   *
+   * @param {object} feedbackMsg - the feedback message sent by the action
+   */
+  const feedbackCallback = useCallback(
+    (feedbackMsg) => {
+      setActionStatus({
+        actionStatus: ROS_ACTION_STATUS_EXECUTE,
+        feedback: feedbackMsg.values.feedback
+      })
+    },
+    [setActionStatus]
+  )
+
   /**
    * Callback function for when the robot has finished moving above the plate.
+   * It moves on to the next meal state.
    */
-  function movingAbovePlateDone() {
+  const movingAbovePlateDone = useCallback(() => {
     console.log('movingAbovePlateDone')
     setMealState(MEAL_STATE.U_BiteSelection)
+  }, [setMealState])
+
+  /**
+   * Callback function for when the action sends a response. It updates the
+   * actionStatus local state variable and moves on to the next state if the
+   * action succeeded.
+   *
+   * TODO: What should happen if the action succeeds, but a response is never
+   * received e.g., due to a momentary networking issue? We should likely allow
+   * the user to press a button to move on if a response hasn't been received
+   * within n seconds of making the action call. Or allow the user to retry the
+   * action call (maybe they would refresh the page anyway, which might be ok).
+   */
+  const responseCallback = useCallback(
+    (response) => {
+      if (response.response_type == 'result' && response.values.status == MOTION_STATUS_SUCCESS) {
+        setActionStatus({
+          actionStatus: ROS_ACTION_STATUS_SUCCEED
+        })
+        movingAbovePlateDone()
+      } else {
+        if (
+          response.response_type == 'cancel' ||
+          response.values == ROS_ACTION_STATUS_CANCEL_GOAL ||
+          response.values == ROS_ACTION_STATUS_CANCELED
+        ) {
+          setActionStatus({
+            actionStatus: ROS_ACTION_STATUS_CANCELED
+          })
+        } else {
+          setActionStatus({
+            actionStatus: ROS_ACTION_STATUS_ABORT
+          })
+        }
+      }
+    },
+    [movingAbovePlateDone, setActionStatus]
+  )
+
+  /**
+   * Callback function for when the pause button is pressed. It cancels the
+   * action.
+   */
+  const pauseCallback = useCallback(() => {
+    cancelROSAction(moveAbovePlateAction)
+  }, [moveAbovePlateAction])
+
+  /**
+   * Function to call the ROS action. Note that every time this function
+   * is called it re-registers callbacks, so typically callbacks should only
+   * be passed the first time it is called.
+   *
+   * @param {function} feedbackCb - the callback function for when the action
+   * sends feedback
+   * @param {function} responseCb - the callback function for when the action
+   * sends a response
+   */
+  const callMoveAbovePlate = useCallback(
+    (feedbackCb, responseCb) => {
+      if (!paused) {
+        setActionStatus({
+          actionStatus: ROS_ACTION_STATUS_EXECUTE
+        })
+        callROSAction(moveAbovePlateAction, {}, feedbackCb, responseCb)
+      }
+    },
+    [moveAbovePlateAction, setActionStatus]
+  )
+  /**
+   * Calls the action the first time this component is rendered, but not upon
+   * any additional re-renders. See here for more details on how `useEffect`
+   * achieves this goal: https://stackoverflow.com/a/69264685
+   */
+  useEffect(() => {
+    callMoveAbovePlate(feedbackCallback, responseCallback)
+    // In practice, because the values passed in in the second argument of
+    // useEffect will not change on re-renders, this return statement will
+    // only be called when the component unmounts.
+    return () => {
+      destroyActionClient(moveAbovePlateAction)
+    }
+  }, [callMoveAbovePlate, moveAbovePlateAction, feedbackCallback, responseCallback])
+
+  /**
+   * Callback function for when the resume button is pressed. It calls the
+   * action once again.
+   */
+  const resumeCallback = useCallback(() => {
+    callMoveAbovePlate(null, null) // don't re-register the callbacks
+  }, [callMoveAbovePlate])
+
+  /**
+   * Get the action status text to render. Note that once Issue #22 is addressed,
+   * this will likely no longer be necessary (since that issue focuses on
+   * visually rendering robot progress).
+   *
+   * @returns {JSX.Element} the action status text to render
+   */
+  let actionStatusText = function () {
+    switch (actionStatus.actionStatus) {
+      case ROS_ACTION_STATUS_EXECUTE:
+        if (actionStatus.feedback) {
+          if (!actionStatus.feedback.is_planning) {
+            let progress = 1 - actionStatus.feedback.motion_curr_distance / actionStatus.feedback.motion_initial_distance
+            return (
+              <>
+                <h3>Robot is moving...</h3>
+                <h3>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Progress: {Math.round(progress * 100)}%</h3>
+              </>
+            )
+          } else {
+            let elapsed_time = actionStatus.feedback.planning_time.sec + actionStatus.feedback.planning_time.nanosec / 10 ** 9
+            return (
+              <>
+                <h3>Robot is thinking...</h3>
+                <h3>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Elapsed Time: {Math.round(elapsed_time * 100) / 100} sec</h3>
+              </>
+            )
+          }
+        } else {
+          return <h3></h3>
+        }
+      case ROS_ACTION_STATUS_SUCCEED:
+        return <h3>Robot has finished</h3>
+      case ROS_ACTION_STATUS_ABORT:
+        /**
+         * TODO: Just displaying that the robot faced an error is not useful
+         * to the user. We should think more carefully about what different
+         * error cases might arise, and change the UI accordingly to instruct
+         * users on how to troubleshoot/fix it.
+         */
+        return <h3>Robot encountered an error</h3>
+      case ROS_ACTION_STATUS_CANCELED:
+        return <h3>Robot is paused</h3>
+      default:
+        return <h3></h3>
+    }
   }
 
   // Render the component
@@ -46,17 +230,35 @@ const MovingAbovePlate = (props) => {
           ) : (
             <></>
           )}
+          <br />
+          <br />
+          <br />
+          {/**
+           * TODO (Issue #22): Instead of just displaying progress via text on
+           * the page, we should visually show a progress bar. This will also
+           * negate the need for the `actionStatusText` function.
+           */}
+          {actionStatusText()}
         </div>
       </Row>
       {/**
-       * Display the footer with the Pause button.
+       * Display the footer with the Pause button. MoveAbovePlate has no back
+       * button, because the user can go "forward" to any state with similar
+       * ease as they could go "backwards" to the same state.
        */}
-      <Footer />
+      <Footer
+        pauseCallback={pauseCallback}
+        backCallback={null}
+        backMealState={null}
+        resumeCallback={resumeCallback}
+        paused={paused}
+        setPaused={setPaused}
+      />
     </>
   )
 }
 MovingAbovePlate.propTypes = {
-  debug: PropTypes.bool
+  debug: PropTypes.bool.isRequired
 }
 
 export default MovingAbovePlate

--- a/feedingwebapp/src/Pages/Home/MealStates/MovingToMouth.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/MovingToMouth.jsx
@@ -1,5 +1,5 @@
 // React Imports
-import React from 'react'
+import React, { useState } from 'react'
 import Button from 'react-bootstrap/Button'
 // PropTypes is used to validate that the used props are in fact passed to this
 // Component
@@ -19,6 +19,9 @@ import { useGlobalState, MEAL_STATE } from '../../GlobalState'
  * @params {object} props - contains any properties passed to this Component
  */
 const MovingToMouth = (props) => {
+  // Create a local state variable for whether the robot is paused.
+  const [paused, setPaused] = useState(false)
+
   // Get the relevant global variables
   const setMealState = useGlobalState((state) => state.setMealState)
 
@@ -29,6 +32,15 @@ const MovingToMouth = (props) => {
   function movingtoMouthDone() {
     console.log('movingtoMouthDone')
     setMealState(MEAL_STATE.U_BiteDone)
+  }
+
+  /**
+   * Callback function for when the back button is clicked.
+   */
+  const backMealState = MEAL_STATE.R_MovingAbovePlate
+  function backCallback() {
+    console.log('Back Clicked')
+    setMealState(backMealState)
   }
 
   // Render the component
@@ -52,12 +64,19 @@ const MovingToMouth = (props) => {
       {/**
        * Display the footer with the Pause button.
        */}
-      <Footer />
+      <Footer
+        pauseCallback={() => console.log('Pause Clicked')}
+        backCallback={backCallback}
+        backMealState={backMealState}
+        resumeCallback={() => console.log('Resume Clicked')}
+        paused={paused}
+        setPaused={setPaused}
+      />
     </>
   )
 }
 MovingToMouth.propTypes = {
-  debug: PropTypes.bool
+  debug: PropTypes.bool.isRequired
 }
 
 export default MovingToMouth

--- a/feedingwebapp/src/Pages/Home/MealStates/MovingToStagingLocation.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/MovingToStagingLocation.jsx
@@ -1,5 +1,5 @@
 // React Imports
-import React from 'react'
+import React, { useState } from 'react'
 import Button from 'react-bootstrap/Button'
 // PropTypes is used to validate that the used props are in fact passed to this
 // Component
@@ -19,6 +19,9 @@ import { useGlobalState, MEAL_STATE } from '../../GlobalState'
  * @params {object} props - contains any properties passed to this Component
  */
 const MovingToStagingLocation = (props) => {
+  // Create a local state variable for whether the robot is paused.
+  const [paused, setPaused] = useState(false)
+
   // Get the relevant global variables
   const setMealState = useGlobalState((state) => state.setMealState)
 
@@ -29,6 +32,15 @@ const MovingToStagingLocation = (props) => {
   function movingToStagingLocationDone() {
     console.log('movingToStagingLocationDone')
     setMealState(MEAL_STATE.U_BiteInitiation)
+  }
+
+  /**
+   * Callback function for when the back button is clicked.
+   */
+  const backMealState = MEAL_STATE.R_MovingAbovePlate
+  function backCallback() {
+    console.log('Back Clicked')
+    setMealState(backMealState)
   }
 
   // Render the component
@@ -56,12 +68,19 @@ const MovingToStagingLocation = (props) => {
       {/**
        * Display the footer with the Pause button.
        */}
-      <Footer />
+      <Footer
+        pauseCallback={() => console.log('Pause Clicked')}
+        backCallback={backCallback}
+        backMealState={backMealState}
+        resumeCallback={() => console.log('Resume Clicked')}
+        paused={paused}
+        setPaused={setPaused}
+      />
     </>
   )
 }
 MovingToStagingLocation.propTypes = {
-  debug: PropTypes.bool
+  debug: PropTypes.bool.isRequired
 }
 
 export default MovingToStagingLocation

--- a/feedingwebapp/src/Pages/Home/MealStates/StowingArm.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/StowingArm.jsx
@@ -1,5 +1,5 @@
 // React Imports
-import React from 'react'
+import React, { useState } from 'react'
 import Button from 'react-bootstrap/Button'
 // PropTypes is used to validate that the used props are in fact passed to this
 // Component
@@ -19,6 +19,9 @@ import { useGlobalState, MEAL_STATE } from '../../GlobalState'
  * @params {object} props - contains any properties passed to this Component
  */
 const StowingArm = (props) => {
+  // Create a local state variable for whether the robot is paused.
+  const [paused, setPaused] = useState(false)
+
   // Get the relevant global variables
   const setMealState = useGlobalState((state) => state.setMealState)
 
@@ -28,6 +31,15 @@ const StowingArm = (props) => {
   function stowingArmDone() {
     console.log('stowingArmDone')
     setMealState(MEAL_STATE.U_PostMeal)
+  }
+
+  /**
+   * Callback function for when the back button is clicked.
+   */
+  const backMealState = MEAL_STATE.R_MovingAbovePlate
+  function backCallback() {
+    console.log('Back Clicked')
+    setMealState(backMealState)
   }
 
   // Render the component
@@ -51,12 +63,19 @@ const StowingArm = (props) => {
       {/**
        * Display the footer with the Pause button.
        */}
-      <Footer />
+      <Footer
+        pauseCallback={() => console.log('Pause Clicked')}
+        backCallback={backCallback}
+        backMealState={backMealState}
+        resumeCallback={() => console.log('Resume Clicked')}
+        paused={paused}
+        setPaused={setPaused}
+      />
     </>
   )
 }
 StowingArm.propTypes = {
-  debug: PropTypes.bool
+  debug: PropTypes.bool.isRequired
 }
 
 export default StowingArm

--- a/feedingwebapp/src/ros/TestROSService.jsx
+++ b/feedingwebapp/src/ros/TestROSService.jsx
@@ -23,6 +23,9 @@ function TestROSService() {
   let { ros } = connectToROS()
 
   // Create the Service
+  // TODO (amaln): This way of creating a ROS Service is inefficient since it
+  // will keep getting re-defined any time the UI changes. Use local state
+  // instead.
   let reverseStringService = createROSService(ros, serviceName, 'feeding_web_app_ros2_msgs/ReverseString')
 
   // Callback function for when the user clicks the "Call" button

--- a/feedingwebapp/src/ros/ros_helpers.js
+++ b/feedingwebapp/src/ros/ros_helpers.js
@@ -152,6 +152,15 @@ export function callROSAction(actionClient, goal, feedbackCallback, resultCallba
  * @param {object} actionClient The ROSLIB.ActionHandle object.
  */
 export function cancelROSAction(actionClient) {
-  console.log('Cancelling ROS action', actionClient)
   actionClient.cancelGoal()
+}
+
+/**
+ * Destroys an action client on the rosbridge end (e.g., so when the user returns
+ * to the same state, it doesn't create a second client for the same action.)
+ *
+ * @param {object} actionClient The ROSLIB.ActionHandle object.
+ */
+export function destroyActionClient(actionClient) {
+  actionClient.destroyClient()
 }


### PR DESCRIPTION
[Describe this pull request. Link to relevant GitHub issues, if any.]

In service of #27 .

This PR does the following:
- Creates ROS2 messages for the actions and services that the web app will use. These changes are in affiliated PR [ada_feeding#19](https://github.com/personalrobotics/ada_feeding/pull/19). 
- Implements a dummy ROS actions for `MoveAbovePlate`. This dummy action sleeps for 2.5 secs during planning, and 10 secs during motion.
- Has the web app call this action where appropriate, and render its feedback/results. 
- In order to do the above, this PR also implements the generalizes the Footer to take in a `pause` state and pause/resume callbacks from the main app page, as opposed to creating it locally in that component.

[Explain how this pull request was tested, including but not limited to the below checkmarks.]

I first tested the ROS Action in isolation, by ensuring that it behaved as expected when:
- It is called and is allowed to finish uninterrupted. (Should return periodic feedback and then success status).
- It is called and then canceled during planning. (Should return periodic feedback and then cancel status).
- It is called and then canceled during motion. (Should return periodic feedback and then cancel status).
- A second goal is sent while first goal is executing. (Should reject the second goal.)
- A second goal is sent after canceling the first goal during planning. (Should accept the second goal.)
- A second goal is sent after canceling the first goal during motion. (Should accept the second goal.)
- A second goal is sent after the first goal succeeds. (Should accept the second goal.)
- Planning fails (returns `success==false`). (Should return planning failure.)
- Motion fails (returns `success==false`). (Should return motion failure.)

I then tested the web app's usage of the ROS action by, for the MoveAbovePlate page:
- Checking that, in normal usage, it calls the ROS action exactly once upon page loading, properly renders the feedback, and moves onto the next state.
- Checking that "pause" cancels the ROS action, and "resume" re-calls it. Verifying that all these call are made exactly once.
- Verifying that if the page is refreshed it cancels the ROS action.

***

**Before creating a pull request**

- [X] Format code with `npm run format`
- [X] Thoroughly test your code's functionality, including unintended uses.
- [N/A, no visual changes that are intended to be in the final app] Thoroughly test your code's responsiveness by rendering it on different devices, browsers, etc.
- [N/A, doesn't change the user flow] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
