### PR TITLE
Fixed circle bar size on RobotMotion page

### DIFF
--- a/feedingwebapp/src/Pages/Home/MealStates/CircleProgressBar.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/CircleProgressBar.jsx
@@ -3,6 +3,7 @@ import { Circle } from './progressbar.js'
 // React imports
 import React, { useEffect, useState } from 'react'
 import { useMediaQuery } from 'react-responsive'
+import { View } from 'react-native'
 // PropTypes is used to validate that the used props are in fact passed to this Component
 import PropTypes from 'prop-types'
 
@@ -19,7 +20,8 @@ export default function CircleProgressBar(props) {
   const isPortrait = useMediaQuery({ query: '(orientation: portrait)' })
   // define sizes of progressbar (width, height, fontsize) in portrait and landscape
   let textFontSize = isPortrait ? '9vh' : '5vw'
-  let circleSize = isPortrait ? '40vh' : '16vw'
+  let circleWidth = isPortrait ? '100%' : null
+  let circleHeight = isPortrait ? null : '100%'
 
   // useEffect React Hook is used to synchronize with RobotMotion.jsx data.
   useEffect(() => {
@@ -58,7 +60,9 @@ export default function CircleProgressBar(props) {
     // everytime items in dependency array (the second argument) update, useEffect runs.
   }, [setBar, bar, props.proportion, textFontSize])
   // render HTML
-  return <div id='container' style={{ margin: '20px', width: circleSize, height: circleSize, position: 'relative' }}></div>
+  return (
+    <View id='container' style={{ flex: 1, margin: '20px', width: circleWidth, height: circleHeight, justifyContent: 'center' }}></View>
+  )
 }
 
 // progress proportion corresponding with the motion the robot is executing

--- a/feedingwebapp/src/Pages/Home/MealStates/RobotMotion.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/RobotMotion.jsx
@@ -266,7 +266,8 @@ const RobotMotion = (props) => {
    * @returns {JSX.Element} the action status text to render
    */
   const actionStatusText = useCallback(
-    (actionStatus) => {
+    (actionStatus, flexSizeOuter) => {
+      let flexSizeInner = isPortrait ? null : 1
       switch (actionStatus.actionStatus) {
         case ROS_ACTION_STATUS_EXECUTE:
           if (actionStatus.feedback) {
@@ -275,59 +276,51 @@ const RobotMotion = (props) => {
               let moving_elapsed_time = actionStatus.feedback.motion_time.sec + actionStatus.feedback.motion_time.nanosec / 10 ** 9
               // Calling CircleProgessBar component to visualize robot motion of moving
               return (
-                <>
-                  <View style={{ flex: 1, flexDirection: dimension, alignItems: 'center' }}>
-                    <View style={{ flex: 5, alignItems: 'center' }}>
-                      <h3 style={{ fontSize: motionTextFontSize }}>Robot is moving...</h3>
-                      <h3 style={{ fontSize: motionTextFontSize }}>
-                        &nbsp;&nbsp;Elapsed Time: {Math.round(moving_elapsed_time * 100) / 100} sec
-                      </h3>
-                    </View>
-                    <View style={{ flex: 5, alignItems: 'center' }}>
-                      <CircleProgressBar proportion={progress} />
-                    </View>
+                <View style={{ flex: flexSizeOuter, flexDirection: dimension, alignItems: 'center' }}>
+                  <View style={{ flex: flexSizeInner, alignItems: 'center', justifyContent: 'center' }}>
+                    <h3 style={{ fontSize: motionTextFontSize }}>Robot is moving...</h3>
+                    <h3 style={{ fontSize: motionTextFontSize }}>
+                      &nbsp;&nbsp;Elapsed Time: {Math.round(moving_elapsed_time * 100) / 100} sec
+                    </h3>
                   </View>
-                </>
+                  <View style={{ flex: flexSizeInner, alignItems: 'center', height: '100%' }}>
+                    <CircleProgressBar proportion={progress} />
+                  </View>
+                </View>
               )
             } else {
               let planning_elapsed_time = actionStatus.feedback.planning_time.sec + actionStatus.feedback.planning_time.nanosec / 10 ** 9
               return (
-                <>
-                  <View style={{ flex: 1, flexDirection: dimension, alignItems: 'center' }}>
-                    <View style={{ flex: 5, alignItems: 'center' }}>
-                      <h3 style={{ fontSize: motionTextFontSize }}>Robot is thinking...</h3>
-                      <h3 style={{ fontSize: motionTextFontSize }}>
-                        &nbsp;&nbsp;Elapsed Time: {Math.round(planning_elapsed_time * 100) / 100} sec
-                      </h3>
-                    </View>
-                    <View style={{ flex: 5, alignItems: 'center' }}>{phantomView()}</View>
+                <View style={{ flex: flexSizeOuter, flexDirection: dimension, alignItems: 'center' }}>
+                  <View style={{ flex: flexSizeInner, alignItems: 'center', justifyContent: 'center' }}>
+                    <h3 style={{ fontSize: motionTextFontSize }}>Robot is thinking...</h3>
+                    <h3 style={{ fontSize: motionTextFontSize }}>
+                      &nbsp;&nbsp;Elapsed Time: {Math.round(planning_elapsed_time * 100) / 100} sec
+                    </h3>
                   </View>
-                </>
+                  <View style={{ flex: flexSizeInner, alignItems: 'center' }}>{phantomView()}</View>
+                </View>
               )
             }
           } else {
             // If you haven't gotten feedback yet, assume the robot is planning
             return (
-              <>
-                <View style={{ flex: 1, flexDirection: dimension, alignItems: 'center' }}>
-                  <View style={{ flex: 5, alignItems: 'center' }}>
-                    <h3 style={{ fontSize: motionTextFontSize }}>Robot is thinking...</h3>
-                  </View>
-                  <View style={{ flex: 5, alignItems: 'center' }}>{phantomView()}</View>
+              <View style={{ flex: flexSizeOuter, flexDirection: dimension, alignItems: 'center' }}>
+                <View style={{ flex: flexSizeInner, alignItems: 'center', justifyContent: 'center' }}>
+                  <h3 style={{ fontSize: motionTextFontSize }}>Robot is thinking...</h3>
                 </View>
-              </>
+                <View style={{ flex: flexSizeInner, alignItems: 'center' }}>{phantomView()}</View>
+              </View>
             )
           }
         case ROS_ACTION_STATUS_SUCCEED:
           return (
-            <>
-              <View style={{ flex: 1, flexDirection: dimension, alignItems: 'center' }}>
-                <View style={{ flex: 5, alignItems: 'center' }}>
-                  <h3 style={{ fontSize: motionTextFontSize }}>Robot has finished</h3>
-                </View>
-                <View style={{ flex: 5, alignItems: 'center' }}>{phantomView()}</View>
+            <View style={{ flex: flexSizeOuter, flexDirection: dimension, alignItems: 'center' }}>
+              <View style={{ flex: flexSizeInner, alignItems: 'center', justifyContent: 'center' }}>
+                <h3 style={{ fontSize: motionTextFontSize }}>Robot has finished</h3>
               </View>
-            </>
+              <View style={{ flex: flexSizeInner, alignItems: 'center' }}>{phantomView()}</View>
+            </View>
           )
         case ROS_ACTION_STATUS_ABORT:
           /**
@@ -337,44 +330,42 @@ const RobotMotion = (props) => {
            * users on how to troubleshoot/fix it.
            */
           return (
-            <>
-              <View style={{ flex: 1, flexDirection: dimension, alignItems: 'center' }}>
-                <View style={{ flex: 5, alignItems: 'center' }}>
-                  <h3 style={{ fontSize: motionTextFontSize }}>Robot encountered an error</h3>
-                </View>
-                <View style={{ flex: 5, alignItems: 'center' }}>{phantomView()}</View>
+            <View style={{ flex: flexSizeOuter, flexDirection: dimension, alignItems: 'center' }}>
+              <View style={{ flex: flexSizeInner, alignItems: 'center', justifyContent: 'center' }}>
+                <h3 style={{ fontSize: motionTextFontSize }}>Robot encountered an error</h3>
               </View>
-            </>
+              <View style={{ flex: flexSizeInner, alignItems: 'center' }}>{phantomView()}</View>
+            </View>
           )
         case ROS_ACTION_STATUS_CANCELED:
           return (
-            <>
-              <View style={{ flex: 1, flexDirection: dimension, alignItems: 'center' }}>
-                <View style={{ flex: 5, alignItems: 'center' }}>
-                  <h3 style={{ fontSize: motionTextFontSize }}>Robot is paused</h3>
-                </View>
-                <View style={{ flex: 5, alignItems: 'center' }}>{phantomView()}</View>
+            <View style={{ flex: flexSizeOuter, flexDirection: dimension, alignItems: 'center' }}>
+              <View style={{ flex: flexSizeInner, alignItems: 'center' }}>
+                <h3 style={{ fontSize: motionTextFontSize }}>Robot is paused</h3>
               </View>
-            </>
+              <View style={{ flex: flexSizeInner, alignItems: 'center' }}>{phantomView()}</View>
+            </View>
           )
         default:
           if (paused) {
             return (
-              <>
-                <View style={{ flex: 1, flexDirection: dimension, alignItems: 'center' }}>
-                  <View style={{ flex: 5, alignItems: 'center' }}>
-                    <h3 style={{ fontSize: motionTextFontSize }}>Robot is paused</h3>
-                  </View>
-                  <View style={{ flex: 5, alignItems: 'center' }}>{phantomView()}</View>
+              <View style={{ flex: flexSizeOuter, flexDirection: dimension, alignItems: 'center' }}>
+                <View style={{ flex: flexSizeInner, alignItems: 'center', justifyContent: 'center' }}>
+                  <h3 style={{ fontSize: motionTextFontSize }}>Robot is paused</h3>
                 </View>
-              </>
+                <View style={{ flex: flexSizeInner, alignItems: 'center' }}>{phantomView()}</View>
+              </View>
             )
           } else {
-            return <h3>&nbsp;</h3>
+            return (
+              <View style={{ flex: flexSizeOuter, flexDirection: dimension, alignItems: 'center' }}>
+                <h3>&nbsp;</h3>
+              </View>
+            )
           }
       }
     },
-    [paused, motionTextFontSize, dimension, phantomView]
+    [isPortrait, paused, motionTextFontSize, dimension, phantomView]
   )
 
   // Render the component
@@ -382,11 +373,14 @@ const RobotMotion = (props) => {
     <>
       {/* TODO: Consider vertically centering this element */}
       <View style={{ flex: 'auto', justifyContent: 'center', width: '100%' }}>
-        <div style={{ width: '100%' }}>
-          <h1 id='Waiting for robot motion' className='waitingMsg' style={{ fontSize: waitingTextFontSize }}>
-            {props.waitingText}
-            {isPortrait ? <h1>&nbsp;</h1> : <></>}
-          </h1>
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <View style={{ flex: isPortrait ? null : 2, justifyContent: 'center' }}>
+            <h1 id='Waiting for robot motion' className='waitingMsg' style={{ fontSize: waitingTextFontSize }}>
+              {props.waitingText}
+              {isPortrait ? <h1>&nbsp;</h1> : <></>}
+            </h1>
+            <br />
+          </View>
           {props.debug ? (
             <Button variant='secondary' className='justify-content-center mx-2 mb-2' size='lg' onClick={robotMotionDone}>
               Continue (Debug Mode)
@@ -394,9 +388,8 @@ const RobotMotion = (props) => {
           ) : (
             <></>
           )}
-          <br />
-          {actionStatusText(actionStatus)}
-        </div>
+          {actionStatusText(actionStatus, isPortrait ? null : 8)}
+        </View>
       </View>
       {/**
        * Display the footer with the Pause button.


### PR DESCRIPTION
The previous setup had the circle progress bar appearing way too small on iPad landscape, because it was setting the circle size as a function of viewport width/height even though what really matters is the **available width/height**. To address this, I leaned into FlexBox and percent-based widths and heights. There were a few key insights I applied to this code.

- All nested elements must be flex Views for flexBox to work correctly.
- If percent-based width and height aren't working, that's because the parent element is not the size you expect. Use "Inspect Element" to identify and fix the issue.
- In some cases, we only want to set some style attributes in either portrait or landscape, and leave them unset in the other. Use `null` for this.