### PR TITLE
Fix Video Scaling Responsiveness

### DIFF
--- a/feedingwebapp/src/Pages/Header/LiveVideoModal.jsx
+++ b/feedingwebapp/src/Pages/Header/LiveVideoModal.jsx
@@ -1,5 +1,5 @@
 // React imports
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useRef } from 'react'
 import { useMediaQuery } from 'react-responsive'
 // The Modal is a screen that appears on top of the main app, and can be toggled
 // on and off.
@@ -9,8 +9,8 @@ import Modal from 'react-bootstrap/Modal'
 import PropTypes from 'prop-types'
 
 // Local imports
-import { REALSENSE_WIDTH, REALSENSE_HEIGHT } from '../Constants'
-import { useWindowSize, convertRemToPixels, scaleWidthHeightToWindow, showVideo } from '../../helpers'
+import { convertRemToPixels } from '../../helpers'
+import VideoFeed from '../Home/VideoFeed'
 
 /**
  * The LiveVideoModal displays to the user the live video feed from the robot.
@@ -18,51 +18,12 @@ import { useWindowSize, convertRemToPixels, scaleWidthHeightToWindow, showVideo 
  * TODO: Consider what will happen if the connection to ROS isn't working.
  */
 function LiveVideoModal(props) {
-  const ref = useRef(null)
-  // Use the default CSS properties of Modals to determine the margin around
-  // the image. This is necessary so the image is scaled to fit the window.
-  //
-  // NOTE: This must change if the CSS properties of the Modal change.
-  //
-  // marginTop: bs-modal-header-padding, h4 font size & line height, bs-modal-header-padding, bs-modal-padding
-  const marginTop = convertRemToPixels(1 + 1.5 * 1.5 + 1 + 1)
-  const marginBottom = convertRemToPixels(1)
-  const marginLeft = convertRemToPixels(1)
-  const marginRight = convertRemToPixels(1)
+  // Variables to render the VideoFeed
+  const modalBodyRef = useRef(null)
+  const margin = convertRemToPixels(1)
 
-  // Get current window size
-  let windowSize = useWindowSize()
-  // Define variables for width and height of image
-  const [imgWidth, setImgWidth] = useState(windowSize.width)
-  const [imgHeight, setImgHeight] = useState(windowSize.height)
   // Flag to check if the current orientation is portrait
   const isPortrait = useMediaQuery({ query: '(orientation: portrait)' })
-
-  /** Factors to modify video size in landscape to fit space
-   *
-   * TODO: Adjust it accordingly when flexbox with directional arrows implemented
-   */
-  let landscapeSizeFactor = 0.9
-
-  // Get final image size according to screen orientation
-  let finalImgWidth = isPortrait ? imgWidth : landscapeSizeFactor * imgWidth
-  let finalImgHeight = isPortrait ? imgHeight : landscapeSizeFactor * imgHeight
-
-  // Update the image size when the screen changes size.
-  useEffect(() => {
-    // 640 x 480 is the standard dimension of images outputed by the RealSense
-    let { width: widthUpdate, height: heightUpdate } = scaleWidthHeightToWindow(
-      windowSize,
-      REALSENSE_WIDTH,
-      REALSENSE_HEIGHT,
-      marginTop,
-      marginBottom,
-      marginLeft,
-      marginRight
-    )
-    setImgWidth(widthUpdate)
-    setImgHeight(heightUpdate)
-  }, [windowSize, marginTop, marginBottom, marginLeft, marginRight])
 
   return (
     <Modal
@@ -74,7 +35,6 @@ function LiveVideoModal(props) {
       keyboard={false}
       centered
       id='liveVideoModal'
-      ref={ref}
       fullscreen={true}
     >
       <Modal.Header closeButton>
@@ -82,8 +42,17 @@ function LiveVideoModal(props) {
           Live Video
         </Modal.Title>
       </Modal.Header>
-      <Modal.Body style={{ overflow: 'hidden' }}>
-        <center>{showVideo(props.webVideoServerURL, finalImgWidth, finalImgHeight, null)}</center>
+      <Modal.Body ref={modalBodyRef} style={{ overflow: 'hidden' }}>
+        <center>
+          <VideoFeed
+            webVideoServerURL={props.webVideoServerURL}
+            parent={modalBodyRef}
+            marginTop={margin}
+            marginBottom={margin}
+            marginLeft={margin}
+            marginRight={margin}
+          />
+        </center>
       </Modal.Body>
     </Modal>
   )

--- a/feedingwebapp/src/Pages/Home/BiteSelectionUIStates/ImageWithButtonName.jsx
+++ b/feedingwebapp/src/Pages/Home/BiteSelectionUIStates/ImageWithButtonName.jsx
@@ -3,7 +3,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Button from 'react-bootstrap/Button'
 import Row from 'react-bootstrap/Row'
-import { scaleWidthHeightToWindow } from '../../../helpers'
 
 import '../Button.css'
 
@@ -20,8 +19,11 @@ import '../Button.css'
  *        image
  */
 const ImageWithButtonName = (props) => {
-  const width = scaleWidthHeightToWindow(props.imgWidth, props.imgHeight, 0, 0, 0, 0).width
-  const height = scaleWidthHeightToWindow(props.imgWidth, props.imgHeight, 0, 0, 0, 0).height
+  // NOTE: The width and height here may be broken, due to changes in and
+  // then deprecation of the `scaleWidthHeightToWindow` function. Changes were
+  // made (resulting in the below code) but not tested.
+  const width = props.imgWidth
+  const height = props.imgWidth
 
   return (
     <>

--- a/feedingwebapp/src/Pages/Home/BiteSelectionUIStates/ImageWithButtonOverlay.jsx
+++ b/feedingwebapp/src/Pages/Home/BiteSelectionUIStates/ImageWithButtonOverlay.jsx
@@ -1,8 +1,8 @@
 // React Imports
 import React from 'react'
 import Button from 'react-bootstrap/Button'
-import { scaleWidthHeightToWindow } from '../../../helpers'
 import PropTypes from 'prop-types'
+import { REALSENSE_WIDTH, REALSENSE_HEIGHT } from '../../Constants'
 
 import '../Button.css'
 
@@ -23,9 +23,14 @@ import '../Button.css'
  */
 
 const ImageWithButtonOverlay = (props) => {
-  const width = scaleWidthHeightToWindow(props.imgWidth, props.imgHeight, 0, 0, 0, 0).width
-  const height = scaleWidthHeightToWindow(props.imgWidth, props.imgHeight, 0, 0, 0, 0).height
-  const scaleFactor = scaleWidthHeightToWindow(props.imgWidth, props.imgHeight, 0, 0, 0, 0).scaleFactor
+  // NOTE: The width and height here may be broken, due to changes in and
+  // then deprecation of the `scaleWidthHeightToWindow` function. Changes were
+  // made (resulting in the below code) but not tested.
+  const width = props.imgWidth
+  const height = props.imgHeight
+  let scaleFactorWidth = width / REALSENSE_WIDTH
+  let scaleFactorHeight = height / REALSENSE_HEIGHT
+  let scaleFactor = (scaleFactorWidth + scaleFactorHeight) / 2
 
   return (
     <>

--- a/feedingwebapp/src/Pages/Home/BiteSelectionUIStates/ImageWithPointMask.jsx
+++ b/feedingwebapp/src/Pages/Home/BiteSelectionUIStates/ImageWithPointMask.jsx
@@ -2,7 +2,6 @@
 import React, { useState } from 'react'
 import Button from 'react-bootstrap/Button'
 import Row from 'react-bootstrap/Row'
-import { scaleWidthHeightToWindow } from '../../../helpers'
 import PropTypes from 'prop-types'
 
 import '../Button.css'
@@ -18,8 +17,11 @@ import '../Button.css'
  *        the realsense camera
  */
 const ImageWithPointMask = (props) => {
-  const width = scaleWidthHeightToWindow(props.imgWidth, props.imgHeight, 0, 0, 0, 0).width
-  const height = scaleWidthHeightToWindow(props.imgWidth, props.imgHeight, 0, 0, 0, 0).height
+  // NOTE: The width and height here may be broken, due to changes in and
+  // then deprecation of the `scaleWidthHeightToWindow` function. Changes were
+  // made (resulting in the below code) but not tested.
+  const width = props.imgWidth
+  const height = props.imgHeight
   const [foodMasksToDisplay, setFoodMasksToDisplay] = useState([])
 
   const imageClicked = (event) => {

--- a/feedingwebapp/src/Pages/Home/MealStates/PlateLocator.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/PlateLocator.jsx
@@ -1,5 +1,5 @@
 // React Imports
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useRef } from 'react'
 import Button from 'react-bootstrap/Button'
 import { useMediaQuery } from 'react-responsive'
 import { View } from 'react-native'
@@ -10,9 +10,9 @@ import PropTypes from 'prop-types'
 // Local Imports
 import '../Home.css'
 import { useGlobalState, MEAL_STATE } from '../../GlobalState'
-import { REALSENSE_WIDTH, REALSENSE_HEIGHT } from '../../Constants'
-import { useWindowSize, convertRemToPixels, scaleWidthHeightToWindow, showVideo } from '../../../helpers'
+import { convertRemToPixels } from '../../../helpers'
 import { Col, Row, Container } from 'react-bootstrap'
+import VideoFeed from '../VideoFeed'
 
 /**
  * The PlateLocator component appears if the user decides to adjust the position
@@ -25,14 +25,16 @@ const PlateLocator = (props) => {
   const setMealState = useGlobalState((state) => state.setMealState)
   // Get robot motion flag for plate locator
   const setTeleopIsMoving = useGlobalState((state) => state.setTeleopIsMoving)
+
   // Flag to check if the current orientation is portrait
   const isPortrait = useMediaQuery({ query: '(orientation: portrait)' })
   // Indicator of how to arrange screen elements based on orientation
   let dimension = isPortrait ? 'column' : 'row'
-  // Define margin for video
+
+  // Variables to render the VideoFeed
+  const videoParentRef = useRef(null)
   const margin = convertRemToPixels(1)
-  // Get current window size
-  let windowSize = useWindowSize()
+
   // text font size
   let textFontSize = isPortrait ? '3vh' : '3vw'
   // done button width
@@ -41,30 +43,6 @@ const PlateLocator = (props) => {
   let buttonHeight = isPortrait ? '6vh' : '6vw'
   // arrow button width
   let arrowButtonWidth = isPortrait ? '6vh' : '6vw'
-  // Factor to modify video size in landscape which has less space than portrait
-  let landscapeSizeFactor = 0.5
-  // Define variables for width and height of video
-  const [imgWidth, setWidth] = useState(windowSize.width)
-  const [imgHeight, setHeight] = useState(windowSize.height)
-
-  // Update the image size when the screen changes size.
-  useEffect(() => {
-    // Get the size of the robot's live video stream.
-    let { width: imgWidthUpdate, height: imgHeightUpdate } = scaleWidthHeightToWindow(
-      windowSize,
-      REALSENSE_WIDTH,
-      REALSENSE_HEIGHT,
-      margin,
-      margin,
-      margin,
-      margin
-    )
-    setWidth(imgWidthUpdate)
-    setHeight(imgHeightUpdate)
-  }, [windowSize, margin])
-
-  let finalImgWidth = isPortrait ? imgWidth : landscapeSizeFactor * imgWidth
-  let finalImgHeight = isPortrait ? imgHeight : landscapeSizeFactor * imgHeight
 
   /**
    * Callback function for when the user presses one of the buttons to teleop
@@ -195,9 +173,16 @@ const PlateLocator = (props) => {
 
   // Render the component
   return (
-    <View style={{ flex: 'auto', flexDirection: dimension, justifyContent: 'center', alignItems: 'center', margin: margin, width: '100%' }}>
-      <View style={{ flex: 5, alignItems: 'center', justifyContent: 'center' }}>
-        {showVideo(props.webVideoServerURL, finalImgWidth, finalImgHeight, null)}
+    <View style={{ flex: 'auto', flexDirection: dimension, justifyContent: 'center', alignItems: 'center', width: '100%', height: '100%' }}>
+      <View ref={videoParentRef} style={{ flex: 5, alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}>
+        <VideoFeed
+          webVideoServerURL={props.webVideoServerURL}
+          parent={videoParentRef}
+          marginTop={margin}
+          marginBottom={margin}
+          marginLeft={margin}
+          marginRight={margin}
+        />
       </View>
       <View style={{ flex: 5, alignItems: 'center', justifyContent: 'center' }}>
         {directionalArrows()}

--- a/feedingwebapp/src/Pages/Home/VideoFeed.jsx
+++ b/feedingwebapp/src/Pages/Home/VideoFeed.jsx
@@ -1,0 +1,173 @@
+// React Imports
+import React, { useCallback, useEffect, useState } from 'react'
+// PropTypes is used to validate that the used props are in fact passed to this Component
+import PropTypes from 'prop-types'
+
+// Local Imports
+import { CAMERA_FEED_TOPIC, REALSENSE_WIDTH, REALSENSE_HEIGHT } from '../Constants'
+import { useWindowSize } from '../../helpers'
+
+/**
+ * Takes in an imageWidth and imageHeight, and returns a width and height that
+ * maintains the same aspect ratio but fits within the window.
+ *
+ * @param {number} parentWidth the width of the parent DOM element in pixels
+ * @param {number} parentHeight the height of the parent DOM element in pixels
+ * @param {number} imageWidth the original image's width in pixels
+ * @param {number} imageHeight the original image's height in pixels
+ * @param {number} marginTop the desired top margin between window and image, in pixels
+ * @param {number} marginBottom the desired bottom margin between window and image, in pixels
+ * @param {number} marginLeft the desired left margin between window and image, in pixels
+ * @param {number} marginRight the desired right margin between window and image, in pixels
+ *
+ * @returns {object} the width and height of the image that fits within the window and has the requested margins
+ */
+function scaleWidthHeightToWindow(
+  parentWidth,
+  parentHeight,
+  imageWidth,
+  imageHeight,
+  marginTop = 0,
+  marginBottom = 0,
+  marginLeft = 0,
+  marginRight = 0
+) {
+  // Calculate the aspect ratio of the image
+  let imageAspectRatio = imageWidth / imageHeight
+  // Get the aspect ratio of the available subset of the window
+  let availableWidth = parentWidth - marginLeft - marginRight
+  let availableHeight = parentHeight - marginTop - marginBottom
+  let availableAspectRatio = availableWidth / availableHeight
+
+  // Calculate the width and height of the image that fits within the window
+  let returnWidth, returnHeight
+  if (availableAspectRatio > imageAspectRatio) {
+    returnHeight = Math.round(availableHeight)
+    returnWidth = Math.round(imageAspectRatio * returnHeight)
+  } else {
+    returnWidth = Math.round(availableWidth)
+    returnHeight = Math.round(returnWidth / imageAspectRatio)
+  }
+
+  // Calculate the scale factor
+  let scaleFactorWidth = returnWidth / imageWidth
+  let scaleFactorHeight = returnHeight / imageHeight
+  let scaleFactor = (scaleFactorWidth + scaleFactorHeight) / 2
+
+  return {
+    width: returnWidth,
+    height: returnHeight,
+    scaleFactor: scaleFactor
+  }
+}
+
+/**
+ * The VideoFeed component takes in a reference to the parent DOM element, and
+ * displays a video feed that takes up the maximum size within the parent DOM,
+ * while maintaining the aspect ratio of the video feed and respecting specified
+ * margins.
+ *
+ * Note that for this to work, the parent DOM element must have a specified
+ * height and width that does not change with its contents. One way to achieve
+ * this is to ensure the `width` and `height` props of the parent are set.
+ */
+const VideoFeed = (props) => {
+  // Local state variables to keep track of the width and height of the video feed
+  const [imgWidth, setImgWidth] = useState(0)
+  const [imgHeight, setImgHeight] = useState(0)
+  const [scaleFactor, setScaleFactor] = useState(0.0)
+
+  // Callback to resize the image based on the parent width and height
+  const resizeImage = useCallback(() => {
+    if (!props.parent.current) {
+      return
+    }
+    // Get the width and height of the parent DOM element
+    let parentWidth = props.parent.current.clientWidth
+    let parentHeight = props.parent.current.clientHeight
+
+    // Calculate the width and height of the video feed
+    let {
+      width: childWidth,
+      height: childHeight,
+      scaleFactor: childScaleFactor
+    } = scaleWidthHeightToWindow(
+      parentWidth,
+      parentHeight,
+      REALSENSE_WIDTH,
+      REALSENSE_HEIGHT,
+      props.marginTop,
+      props.marginBottom,
+      props.marginLeft,
+      props.marginRight
+    )
+
+    // Set the width and height of the video feed
+    setImgWidth(childWidth)
+    setImgHeight(childHeight)
+    setScaleFactor(childScaleFactor)
+  }, [props.parent, props.marginTop, props.marginBottom, props.marginLeft, props.marginRight])
+
+  // When the component is first mounted, resize the image
+  useEffect(() => {
+    resizeImage()
+  }, [resizeImage])
+
+  // When the window is resized, resize the image
+  useWindowSize(resizeImage)
+
+  // The callback for when the image is clicked.
+  const imageClicked = useCallback(
+    (event) => {
+      // Get the position of the click relative to the raw RealSense image.
+      let rect = event.target.getBoundingClientRect()
+      let x = event.clientX - rect.left // x position within the image.
+      let y = event.clientY - rect.top // y position within the image.
+      let x_raw = Math.round(x / scaleFactor) // x position within the raw image.
+      let y_raw = Math.round(y / scaleFactor) // y position within the raw image.
+      console.log('Button click on unscaled image: (' + x_raw + ', ' + y_raw + ')')
+
+      // Call the callback function if it exists
+      if (props.pointClicked) {
+        props.pointClicked(x_raw, y_raw)
+      }
+    },
+    [props, scaleFactor]
+  )
+
+  // Render the component
+  return (
+    <img
+      src={`${props.webVideoServerURL}/stream?topic=${CAMERA_FEED_TOPIC}&width=${imgWidth}&height=${imgHeight}&quality=20`}
+      alt='Live video feed from the robot'
+      style={{
+        width: imgWidth,
+        height: imgHeight,
+        display: 'block',
+        alignItems: 'center',
+        justifyContent: 'center'
+      }}
+      onClick={props.pointClicked ? imageClicked : null}
+    />
+  )
+}
+VideoFeed.propTypes = {
+  // The ref to the parent DOM element. Null if the component is not yet mounted
+  parent: PropTypes.object.isRequired,
+  // The URL of the video feed
+  webVideoServerURL: PropTypes.string.isRequired,
+  // The margins around the video feed
+  marginTop: PropTypes.number.isRequired,
+  marginBottom: PropTypes.number.isRequired,
+  marginLeft: PropTypes.number.isRequired,
+  marginRight: PropTypes.number.isRequired,
+  /**
+   * An optional callback function for when the user clicks on the video feed.
+   * This function should take in two parameters, `x` and `y`, which are the
+   * coordinates of the click in the **unscaled** image (e.g., the image of
+   * size REALSENSE_WIDTH x REALSENSE_HEIGHT).
+   */
+  pointClicked: PropTypes.func
+}
+
+export default VideoFeed

--- a/feedingwebapp/src/helpers.js
+++ b/feedingwebapp/src/helpers.js
@@ -1,101 +1,26 @@
-import React, { useLayoutEffect, useState } from 'react'
-import { CAMERA_FEED_TOPIC } from './Pages/Constants'
+import { useLayoutEffect, useState } from 'react'
 
-// Updates and returns the window size whenever the screen is re-sized.
-export function useWindowSize() {
+/**
+ * Returns the window size, which gets updated every time the window is resized.
+ *
+ * @param {func} resizeCallback an optional function to call when the window is
+ *     resized. Note that this function cannot use any react hooks.
+ */
+export function useWindowSize(resizeCallback = null) {
   const [windowSize, setWindowSize] = useState({ width: 0, height: 0 })
   useLayoutEffect(() => {
     // set current window size
     function updateWindowSize() {
       setWindowSize({ width: window.innerWidth, height: window.innerHeight })
+      if (resizeCallback) {
+        resizeCallback()
+      }
     }
     window.addEventListener('resize', updateWindowSize)
     updateWindowSize()
     return () => window.removeEventListener('resize', updateWindowSize)
-  }, [])
+  }, [resizeCallback])
   return windowSize
-}
-
-/**
- * Get the robot's live video stream.
- *
- * @param {string} webVideoServerURL The URL of the web video server
- * @param {number} currentWidth the adjusted width in pixels
- * @param {number} currentHeight the adjusted height in pixels
- * @param {func} onclick the function trigerred in video onclick  
- }}
- *
- * @returns {JSX.Element} the robot's live video stream
- */
-export function showVideo(webVideoServerURL, currentWidth, currentHeight, onclick) {
-  let imgWidth = Math.round(currentWidth)
-  let imgHeight = Math.round(currentHeight)
-  return (
-    <img
-      src={`${webVideoServerURL}/stream?topic=${CAMERA_FEED_TOPIC}&width=${imgWidth}&height=${imgHeight}&quality=20`}
-      alt='Live video feed from the robot'
-      style={{
-        width: imgWidth,
-        height: imgHeight,
-        display: 'block',
-        alignItems: 'center',
-        justifyContent: 'center'
-      }}
-      onClick={onclick}
-    />
-  )
-}
-
-/**
- * Takes in an imageWidth and imageHeight, and returns a width and height that
- * maintains the same aspect ratio but fits within the window.
- *
- * @param {number} windowSize the inner width and height of the window
- * @param {number} imageWidth the original image's width in pixels
- * @param {number} imageHeight the original image's height in pixels
- * @param {number} marginTop the desired top margin between window and image, in pixels
- * @param {number} marginBottom the desired bottom margin between window and image, in pixels
- * @param {number} marginLeft the desired left margin between window and image, in pixels
- * @param {number} marginRight the desired right margin between window and image, in pixels
- *
- * @returns {object} the width and height of the image that fits within the window and has the requested margins
- */
-export function scaleWidthHeightToWindow(
-  windowSize,
-  imageWidth,
-  imageHeight,
-  marginTop = 0,
-  marginBottom = 0,
-  marginLeft = 0,
-  marginRight = 0
-) {
-  // Calculate the aspect ratio of the image
-  let imageAspectRatio = imageWidth / imageHeight
-  // Get the aspect ratio of the available subset of the window
-  let availableWidth = windowSize.width - marginLeft - marginRight
-  let availableHeight = windowSize.height - marginTop - marginBottom
-  let availableAspectRatio = availableWidth / availableHeight
-
-  // Calculate the width and height of the image that fits within the window
-  let returnWidth, returnHeight
-  if (availableAspectRatio > imageAspectRatio) {
-    returnHeight = availableHeight
-    returnWidth = imageAspectRatio * returnHeight
-  } else {
-    returnWidth = availableWidth
-    returnHeight = returnWidth / imageAspectRatio
-  }
-
-  // Calculate the scale factor
-  let scaleFactorWidth = returnWidth / imageWidth
-  let scaleFactorHeight = returnHeight / imageHeight
-  let scaleFactor = (scaleFactorWidth + scaleFactorHeight) / 2
-
-  return {
-    width: returnWidth,
-    height: returnHeight,
-    scaleFactor: scaleFactor
-  }
 }
 
 /**


### PR DESCRIPTION
This PR is a fix to an issue that was unable to be resolved in #60 . Specifically, #60 ended up with a bunch of hardcoded scale factors on pages with the robot's video stream, to attempt to make it consistently render properly. However, hardcoded scale factors is not a good code-writing style and is ripe for bugs. This PR addresses that by consistently adding views that take up the full specified width, and then computing the video stream size from those parent components.

Key insights: 
- We should be setting the image’s width and height with respect to the width and height of the **parent View**, not with respect to the **window width and height**.
    - **Key implementation detail**: In order to do that, the parent’s width and height must not adjust based on the content within it. Therefore, the `width` and `height` props for the parent element must be set. Furthermore, a reference to the parent must be passed in to the component that is rendering the video.
- We don’t need to use phantom buttons to fill space if we are intentional about flex box and use `width: 100%`, `height: 100%` to have the views themselves fill up the space.
    - Corollary: by being intentional about Views, we can even remove the need for phantom buttons from the footer.

This PR was tested on the browser's version of the iPhone 12/13 Pro Max and the iPad iOs 14.7.1, in both portrait and landscape mode.