### PR TITLE
Add retry button for error page

### DIFF
--- a/feedingwebapp/src/Pages/Home/MealStates/RobotMotion.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/RobotMotion.jsx
@@ -251,7 +251,7 @@ const RobotMotion = (props) => {
    * @returns {JSX.Element} the action status text, progress bar or blank view
    */
   const actionStatusTextAndVisual = useCallback(
-    (flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress, retry) => {
+    (flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress, retry = false) => {
       return (
         <>
           <View style={{ flex: flexSizeOuter, flexDirection: dimension, alignItems: 'center', justifyContent: 'center', width: '100%' }}>
@@ -305,11 +305,10 @@ const RobotMotion = (props) => {
     (actionStatus, flexSizeOuter) => {
       let flexSizeTextInner = 1
       let flexSizeVisualInner = 1
-      let text
+      let text = 'Robot is paused'
       let showTime = false
       let time = 0
       let progress = null
-      let retry = false
       switch (actionStatus.actionStatus) {
         case ROS_ACTION_STATUS_EXECUTE:
           if (actionStatus.feedback) {
@@ -320,34 +319,22 @@ const RobotMotion = (props) => {
               showTime = true
               progress = 1 - actionStatus.feedback.motion_curr_distance / actionStatus.feedback.motion_initial_distance
               // Calling CircleProgessBar component to visualize robot motion of moving
-              return (
-                <>
-                  {actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress, retry)}
-                </>
-              )
+              return <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress)}</>
             } else {
               let planning_elapsed_time = actionStatus.feedback.planning_time.sec + actionStatus.feedback.planning_time.nanosec / 10 ** 9
               text = 'Robot is thinking...'
               time = Math.round(planning_elapsed_time * 100) / 100
               showTime = true
-              return (
-                <>
-                  {actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress, retry)}
-                </>
-              )
+              return <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress)}</>
             }
           } else {
             // If you haven't gotten feedback yet, assume the robot is planning
             text = 'Robot is thinking...'
-            return (
-              <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress, retry)}</>
-            )
+            return <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress)}</>
           }
         case ROS_ACTION_STATUS_SUCCEED:
           text = 'Robot has finished'
-          return (
-            <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress, retry)}</>
-          )
+          return <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress)}</>
         case ROS_ACTION_STATUS_ABORT:
           /**
            * TODO: Just displaying that the robot faced an error is not useful
@@ -356,21 +343,14 @@ const RobotMotion = (props) => {
            * users on how to troubleshoot/fix it.
            */
           text = 'Robot encountered an error'
-          retry = true
           return (
-            <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress, retry)}</>
+            <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress, true)}</>
           )
         case ROS_ACTION_STATUS_CANCELED:
-          text = 'Robot is paused'
-          return (
-            <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress, retry)}</>
-          )
+          return <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress)}</>
         default:
           if (paused) {
-            text = 'Robot is paused'
-            return (
-              <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress, retry)}</>
-            )
+            return <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress)}</>
           } else {
             return (
               <View


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

This PR includes issue #84 deliverables as detailed in the following:
Added a retry boolean variable in the `RobotMotion.jsx` file. This retry boolean is `true` only when “Robot has encountered an error” text appears. When retry boolean is `true` a **Retry** button appears in the error page. I placed this button in the latter 50% of the page's viewbox and made it vertically and horizontally centered in that part. I used yellow for this button’s color as this is meant for an unintended / erroneous situation. When this button is clicked, the current robot motion starts again from planning, just like what the footer's resume button does when the robot is paused.

UPDATES:
* Assigned default value to `retry` in the function definition
* Changed resumeCallback function onclick
* Placed 'Retry' button in the prior 50% of the page's viewbox

## Explain how this pull request was tested, including but not limited to the below checkmarks.

This feature was tested in Ubuntu VM 22.04 chromium and firefox browser in landscape and portrait modes of smartphone, tablet, desktop monitor, and laptop. The retry button appeared as expected and re-started the current action when the retry button is clicked.

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [N/A] Format Python code by running `python3 -m black .` in the top-level of this repository
- [N/A] Thoroughly test your code's functionality, including unintended uses.
- [x] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [x] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
