### PR TITLE
Have rosbridge set domain name based on URL instead of hard-coded

### DIFF
--- a/feedingwebapp/.env
+++ b/feedingwebapp/.env
@@ -2,11 +2,6 @@
 # from screens that would otherwise wait for ROS messages).
 REACT_APP_DEBUG=false
 
-# The hostname of the ROS server. The app assumes that rosbridge and 
-# web_video_server are both running on the same hostname. Do not include a 
-# protocol (e.g., `http://`, `ws://`, etc.) or a port (e.g., `:9090`) in this
-# environment variable.
-REACT_APP_ROS_SERVER_HOSTNAME="localhost"
 # The port of the rosbridge server (default: 9090)
 REACT_APP_ROSBRIDGE_PORT="9090"
 # The port of the web video server (default: 8080)

--- a/feedingwebapp/src/App.jsx
+++ b/feedingwebapp/src/App.jsx
@@ -56,9 +56,9 @@ function App() {
   const appPage = useGlobalState((state) => state.appPage)
 
   // Get the rosbridge URL
-  const rosbridgeURL = 'ws://'.concat(process.env.REACT_APP_ROS_SERVER_HOSTNAME, ':', process.env.REACT_APP_ROSBRIDGE_PORT)
+  const rosbridgeURL = 'ws://'.concat(window.location.hostname, ':', process.env.REACT_APP_ROSBRIDGE_PORT)
   // Get the web_video_server URL
-  const webVideoServerURL = 'http://'.concat(process.env.REACT_APP_ROS_SERVER_HOSTNAME, ':', process.env.REACT_APP_WEB_VIDEO_SERVER_PORT)
+  const webVideoServerURL = 'http://'.concat(window.location.hostname, ':', process.env.REACT_APP_WEB_VIDEO_SERVER_PORT)
 
   // Get the debug flag
   const debug = process.env.REACT_APP_DEBUG === 'true'


### PR DESCRIPTION
Remove the unnecessary env variable to hardcode the URL.

Tested during the 11-16 demo.