### PR TITLE
Revamp In-App Video Streaming

### DIFF
--- a/feeding_web_app_ros2_test/feeding_web_app_ros2_test/DummyRealSense.py
+++ b/feeding_web_app_ros2_test/feeding_web_app_ros2_test/DummyRealSense.py
@@ -85,6 +85,9 @@ class DummyRealSense(Node):
         self.camera_info_publisher = self.create_publisher(
             CameraInfo, "~/camera_info", 1
         )
+        self.aligned_depth_camera_info_publisher = self.create_publisher(
+            CameraInfo, "~/aligned_depth/camera_info", 1
+        )
         if self.video is not None:
             self.num_frames = 0
         self.bridge = CvBridge()
@@ -174,6 +177,7 @@ class DummyRealSense(Node):
             self.compressed_image_publisher.publish(compressed_frame_msg)
             self.aligned_depth_publisher.publish(depth_frame_msg)
             self.camera_info_publisher.publish(self.camera_info_msg)
+            self.aligned_depth_camera_info_publisher.publish(self.camera_info_msg)
 
             rate.sleep()
 

--- a/feeding_web_app_ros2_test/launch/feeding_web_app_dummy_nodes_launch.xml
+++ b/feeding_web_app_ros2_test/launch/feeding_web_app_dummy_nodes_launch.xml
@@ -10,8 +10,6 @@
   <group if="$(var run_web_bridge)">
     <!-- The ROSBridge Node -->
     <include file="$(find-pkg-share rosbridge_server)/launch/rosbridge_websocket_launch.xml"/>
-    <!-- The ROS web_video_server -->
-    <node pkg="web_video_server" exec="web_video_server" name="web_video_server"/>
   </group>
 
   <!-- The dummy nodes -->
@@ -23,8 +21,9 @@
       <remap from="~/compressed_image" to="/camera/color/image_raw/compressed"/>
       <remap from="~/aligned_depth" to="/camera/aligned_depth_to_color/image_raw"/>
       <remap from="~/camera_info" to="/camera/color/camera_info"/>
+      <remap from="~/aligned_depth/camera_info" to="/camera/aligned_depth_to_color/camera_info"/>
       <param name="fps" value="30"/>
-      <param name="rgb_path" value="$(find-pkg-share feeding_web_app_ros2_test)/../data/above_plate_1_rgb.jpg"/>
+      <param name="rgb_path" value="$(find-pkg-share feeding_web_app_ros2_test)/../data/2022_11_01_ada_picks_up_carrots_camera_compressed_ft_tf.mp4"/>
       <param name="depth_path" value="$(find-pkg-share feeding_web_app_ros2_test)/../data/above_plate_1_depth.png"/>
     </node>
   </group>

--- a/feedingwebapp/src/App.jsx
+++ b/feedingwebapp/src/App.jsx
@@ -22,23 +22,22 @@ import BiteSelectionPointMask from './Pages/Home/BiteSelectionUIStates/BiteSelec
  * @param {APP_PAGE} appPage - The current app page. Must be one of the
  *        states specified in APP_PAGE.
  * @param {string} rosbridgeURL - The URL of the rosbridge server.
- * @param {string} webVideoServerURL - The URL of the web_video_server.
  * @param {bool} debug - Whether to run it in debug mode or not.
  */
-function getComponentByAppPage(appPage, rosbridgeURL, webVideoServerURL, debug) {
+function getComponentByAppPage(appPage, rosbridgeURL, debug) {
   switch (appPage) {
     case APP_PAGE.Home:
       // Must wrap a component in ROS tags for it to be able to connect to ROS
       return (
         <RosConnection url={rosbridgeURL} autoConnect>
-          <Header webVideoServerURL={webVideoServerURL} />
-          <Home debug={debug} webVideoServerURL={webVideoServerURL} />
+          <Header />
+          <Home debug={debug} />
         </RosConnection>
       )
     case APP_PAGE.Settings:
       return (
         <RosConnection url={rosbridgeURL} autoConnect>
-          <Header webVideoServerURL={webVideoServerURL} />
+          <Header />
           <Settings />
         </RosConnection>
       )
@@ -57,8 +56,6 @@ function App() {
 
   // Get the rosbridge URL
   const rosbridgeURL = 'ws://'.concat(window.location.hostname, ':', process.env.REACT_APP_ROSBRIDGE_PORT)
-  // Get the web_video_server URL
-  const webVideoServerURL = 'http://'.concat(window.location.hostname, ':', process.env.REACT_APP_WEB_VIDEO_SERVER_PORT)
 
   // Get the debug flag
   const debug = process.env.REACT_APP_DEBUG === 'true'
@@ -68,7 +65,7 @@ function App() {
     <>
       <Router>
         <Routes>
-          <Route exact path='/' element={getComponentByAppPage(appPage, rosbridgeURL, webVideoServerURL, debug)} />
+          <Route exact path='/' element={getComponentByAppPage(appPage, rosbridgeURL, debug)} />
           <Route
             exact
             path='/test_ros'
@@ -83,7 +80,7 @@ function App() {
             path='/test_bite_selection_ui/button_overlay_selection'
             element={
               <RosConnection url={rosbridgeURL} autoConnect>
-                <Header webVideoServerURL={webVideoServerURL} />
+                <Header />
                 <BiteSelectionButtonOverlay debug={debug} />
               </RosConnection>
             }
@@ -93,7 +90,7 @@ function App() {
             path='/test_bite_selection_ui/point_mask_selection'
             element={
               <RosConnection url={rosbridgeURL} autoConnect>
-                <Header webVideoServerURL={webVideoServerURL} />
+                <Header />
                 <BiteSelectionPointMask debug={debug} />
               </RosConnection>
             }
@@ -103,7 +100,7 @@ function App() {
             path='/test_bite_selection_ui/food_name_selection'
             element={
               <RosConnection url={rosbridgeURL} autoConnect>
-                <Header webVideoServerURL={webVideoServerURL} />
+                <Header />
                 <BiteSelectionName debug={debug} />
               </RosConnection>
             }

--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -48,10 +48,10 @@ NON_MOVING_STATES.add(MEAL_STATE.U_PostMeal)
 export { NON_MOVING_STATES }
 
 // The names of the ROS topic(s)
-export const CAMERA_FEED_TOPIC = '/local/camera/color/image_raw'
+export const CAMERA_FEED_TOPIC = '/local/camera/color/image_raw/compressed'
 export const FACE_DETECTION_TOPIC = '/face_detection'
 export const FACE_DETECTION_TOPIC_MSG = 'ada_feeding_msgs/FaceDetection'
-export const FACE_DETECTION_IMG_TOPIC = '/face_detection_img'
+export const FACE_DETECTION_IMG_TOPIC = '/face_detection_img/compressed'
 
 // States from which, if they fail, it is NOT okay for the user to retry the
 // same action.

--- a/feedingwebapp/src/Pages/Header/Header.jsx
+++ b/feedingwebapp/src/Pages/Header/Header.jsx
@@ -4,9 +4,6 @@ import React, { useCallback, useEffect, useState } from 'react'
 import Navbar from 'react-bootstrap/Navbar'
 import Nav from 'react-bootstrap/Nav'
 import { useMediaQuery } from 'react-responsive'
-// PropTypes is used to validate that the used props are in fact passed to this
-// Component
-import PropTypes from 'prop-types'
 // Toast generates a temporary pop-up with a timeout.
 import { ToastContainer /* , toast */ } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
@@ -23,7 +20,7 @@ import LiveVideoModal from './LiveVideoModal'
  * clicking "Video", and the ToastContainer popup that specifies when the user
  * cannot click Settings.
  */
-const Header = (props) => {
+const Header = () => {
   // Create a local state variable to toggle on/off the video
   // TODO: Since this local state variable is in the header, the LiveVideoModal
   // continues showing even if the state changes. Is this desirable? Perhaps
@@ -166,13 +163,9 @@ const Header = (props) => {
        * The LiveVideoModal toggles on and off with the Video button and shows the
        * robot's live camera feed.
        */}
-      <LiveVideoModal webVideoServerURL={props.webVideoServerURL} show={videoShow} onHide={() => setVideoShow(false)} />
+      <LiveVideoModal show={videoShow} onHide={() => setVideoShow(false)} />
     </>
   )
-}
-Header.propTypes = {
-  // The URL of the ROS web video server
-  webVideoServerURL: PropTypes.string.isRequired
 }
 
 export default Header

--- a/feedingwebapp/src/Pages/Header/LiveVideoModal.jsx
+++ b/feedingwebapp/src/Pages/Header/LiveVideoModal.jsx
@@ -49,7 +49,8 @@ function LiveVideoModal(props) {
       <Modal.Body ref={modalBodyRef} style={{ overflow: 'hidden' }}>
         <center>
           <VideoFeed
-            webVideoServerURL={props.webVideoServerURL}
+            topic='/local/camera/color/image_raw/compressed'
+            updateRateHz={10}
             parent={modalBodyRef}
             marginTop={margin}
             marginBottom={margin}
@@ -65,9 +66,7 @@ LiveVideoModal.propTypes = {
   // Whether or not the modal is visible
   show: PropTypes.bool.isRequired,
   // Callback function for when the modal is hidden
-  onHide: PropTypes.func.isRequired,
-  // The URL of the ROS web video server
-  webVideoServerURL: PropTypes.string.isRequired
+  onHide: PropTypes.func.isRequired
 }
 
 export default LiveVideoModal

--- a/feedingwebapp/src/Pages/Home/Home.jsx
+++ b/feedingwebapp/src/Pages/Home/Home.jsx
@@ -22,7 +22,6 @@ import { TIME_TO_RESET_MS } from '../Constants'
  *
  * @param {boolean} debug - whether to run it in debug mode (e.g., if you aren't
  *        simulatenously running the robot) or not
- * @param {string} webVideoServerURL - the URL of the web video server
  * @returns {JSX.Element}
  */
 function Home(props) {
@@ -94,10 +93,10 @@ function Home(props) {
         )
       }
       case MEAL_STATE.U_BiteSelection: {
-        return <BiteSelection debug={props.debug} webVideoServerURL={props.webVideoServerURL} />
+        return <BiteSelection debug={props.debug} />
       }
       case MEAL_STATE.U_PlateLocator: {
-        return <PlateLocator debug={props.debug} webVideoServerURL={props.webVideoServerURL} />
+        return <PlateLocator debug={props.debug} />
       }
       case MEAL_STATE.R_BiteAcquisition: {
         /**
@@ -153,7 +152,7 @@ function Home(props) {
         )
       }
       case MEAL_STATE.R_DetectingFace: {
-        return <DetectingFace debug={props.debug} webVideoServerURL={props.webVideoServerURL} />
+        return <DetectingFace debug={props.debug} />
       }
       case MEAL_STATE.R_MovingToMouth: {
         /**
@@ -254,7 +253,6 @@ function Home(props) {
   }, [
     mealState,
     props.debug,
-    props.webVideoServerURL,
     biteAcquisitionActionInput,
     moveAbovePlateActionInput,
     moveToMouthActionInput,
@@ -278,9 +276,7 @@ Home.propTypes = {
    * Whether to run it in debug mode (e.g., if you aren't simulatenously running
    * the robot) or not
    */
-  debug: PropTypes.bool,
-  // The URL of the web video server
-  webVideoServerURL: PropTypes.string.isRequired
+  debug: PropTypes.bool
 }
 
 export default Home

--- a/feedingwebapp/src/Pages/Home/MealStates/BiteSelection.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/BiteSelection.jsx
@@ -13,10 +13,7 @@ import { useROS, createROSActionClient, callROSAction, destroyActionClient } fro
 import { useWindowSize, convertRemToPixels } from '../../../helpers'
 import MaskButton from '../../../buttons/MaskButton'
 import {
-  REALSENSE_WIDTH,
-  REALSENSE_HEIGHT,
   ROS_ACTIONS_NAMES,
-  CAMERA_FEED_TOPIC,
   ROS_ACTION_STATUS_CANCEL_GOAL,
   ROS_ACTION_STATUS_EXECUTE,
   ROS_ACTION_STATUS_SUCCEED,
@@ -328,20 +325,13 @@ const BiteSelection = (props) => {
         let maskScaleFactor = Math.min(widthScaleFactor, heightScaleFactor)
         // maskScaleFactor  = Math.min(maskScaleFactor, 1.0)
 
-        // Get the URL of the image based on the scale factor
-        let imgSize = {
-          width: Math.round(REALSENSE_WIDTH * maskScaleFactor),
-          height: Math.round(REALSENSE_HEIGHT * maskScaleFactor)
-        }
-        let imgSrc = `${props.webVideoServerURL}/stream?topic=${CAMERA_FEED_TOPIC}&width=${imgSize.width}&height=${imgSize.height}&type=ros_compressed`
         return (
           <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center', width: '100%', height: '100%' }}>
             {actionResult.detected_items.map((detected_item, i) => (
               <View key={i} style={{ flex: 1, justifyContent: 'center', alignItems: 'center', width: '100%', height: '100%' }}>
                 <MaskButton
-                  imgSrc={imgSrc}
+                  imgSrc={'data:image/jpeg;base64,' + detected_item.rgb_image.data}
                   buttonSize={buttonSize}
-                  imgSize={imgSize}
                   maskSrc={'data:image/jpeg;base64,' + detected_item.mask.data}
                   invertMask={true}
                   maskScaleFactor={maskScaleFactor}
@@ -355,7 +345,7 @@ const BiteSelection = (props) => {
         )
       }
     }
-  }, [actionStatus, actionResult, foodItemClicked, isPortrait, windowSize, props.webVideoServerURL, margin])
+  }, [actionStatus, actionResult, foodItemClicked, isPortrait, windowSize, margin])
 
   /** Get the button for continue without acquiring bite
    *
@@ -480,12 +470,12 @@ const BiteSelection = (props) => {
               style={{
                 flex: 9,
                 alignItems: 'center',
+                justifyContent: 'center',
                 width: '100%',
                 height: '100%'
               }}
             >
               <VideoFeed
-                webVideoServerURL={props.webVideoServerURL}
                 parent={videoParentRef}
                 marginTop={margin}
                 marginBottom={margin}
@@ -576,7 +566,6 @@ const BiteSelection = (props) => {
     actionStatusText,
     renderMaskButtons,
     skipAcquisisitionButton,
-    props.webVideoServerURL,
     videoParentRef,
     imageClicked,
     props.debug,
@@ -591,9 +580,7 @@ BiteSelection.propTypes = {
    * Whether to run it in debug mode (e.g., if you aren't simulatenously running
    * the robot) or not
    */
-  debug: PropTypes.bool.isRequired,
-  // The URL of the web video server
-  webVideoServerURL: PropTypes.string.isRequired
+  debug: PropTypes.bool.isRequired
 }
 
 export default BiteSelection

--- a/feedingwebapp/src/Pages/Home/MealStates/DetectingFace.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/DetectingFace.jsx
@@ -3,9 +3,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Button from 'react-bootstrap/Button'
 import { useMediaQuery } from 'react-responsive'
 import { View } from 'react-native'
-// PropTypes is used to validate that the used props are in fact passed to this
-// Component
-import PropTypes from 'prop-types'
 
 // Local Imports
 import { useROS, createROSService, createROSServiceRequest, subscribeToROSTopic, unsubscribeFromROSTopic } from '../../../ros/ros_helpers'
@@ -26,7 +23,7 @@ import VideoFeed from '../VideoFeed'
  * configuration. It displays the output of face detection, and automatically
  * moves on to `R_MovingToMouth` when a face is detected.
  */
-const DetectingFace = (props) => {
+const DetectingFace = () => {
   // Keep track of whether a mouth has been detected or not
   const [mouthDetected, setMouthDetected] = useState(false)
   // Get the relevant global variables
@@ -203,14 +200,12 @@ const DetectingFace = (props) => {
               }}
             >
               <VideoFeed
-                webVideoServerURL={props.webVideoServerURL}
                 parent={videoParentRef}
                 marginTop={margin}
                 marginBottom={margin}
                 marginLeft={margin}
                 marginRight={margin}
                 topic={FACE_DETECTION_IMG_TOPIC}
-                type='mjpeg&quality=20'
               />
             </View>
           </View>
@@ -238,7 +233,6 @@ const DetectingFace = (props) => {
     mouthDetected,
     moveToMouthCallback,
     moveToMouthImage,
-    props.webVideoServerURL,
     textFontSize,
     buttonHeight,
     buttonWidth,
@@ -251,14 +245,4 @@ const DetectingFace = (props) => {
   // Render the component
   return fullPageView()
 }
-DetectingFace.propTypes = {
-  /**
-   * Whether to run it in debug mode (e.g., if you aren't simulatenously running
-   * the robot) or not
-   */
-  debug: PropTypes.bool.isRequired,
-  // The URL of the web video server
-  webVideoServerURL: PropTypes.string.isRequired
-}
-
 export default DetectingFace

--- a/feedingwebapp/src/Pages/Home/MealStates/PlateLocator.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/PlateLocator.jsx
@@ -3,9 +3,6 @@ import React, { useCallback, useMemo, useRef } from 'react'
 import Button from 'react-bootstrap/Button'
 import { useMediaQuery } from 'react-responsive'
 import { View } from 'react-native'
-// PropTypes is used to validate that the used props are in fact passed to this
-// Component
-import PropTypes from 'prop-types'
 
 // Local Imports
 import '../Home.css'
@@ -20,7 +17,7 @@ import VideoFeed from '../VideoFeed'
  * the user to teleoperate the robot with Cartesian Control until the plate
  * is satisfactorily in view.
  */
-const PlateLocator = (props) => {
+const PlateLocator = () => {
   // Get the relevant global variables
   const setMealState = useGlobalState((state) => state.setMealState)
   // Get robot motion flag for plate locator
@@ -179,14 +176,7 @@ const PlateLocator = (props) => {
   return (
     <View style={{ flex: 'auto', flexDirection: dimension, justifyContent: 'center', alignItems: 'center', width: '100%', height: '100%' }}>
       <View ref={videoParentRef} style={{ flex: 5, alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}>
-        <VideoFeed
-          webVideoServerURL={props.webVideoServerURL}
-          parent={videoParentRef}
-          marginTop={margin}
-          marginBottom={margin}
-          marginLeft={margin}
-          marginRight={margin}
-        />
+        <VideoFeed parent={videoParentRef} marginTop={margin} marginBottom={margin} marginLeft={margin} marginRight={margin} />
       </View>
       <View style={{ flex: 5, alignItems: 'center', justifyContent: 'center' }}>
         {directionalArrows()}
@@ -194,10 +184,6 @@ const PlateLocator = (props) => {
       </View>
     </View>
   )
-}
-PlateLocator.propTypes = {
-  // The URL of the web video server
-  webVideoServerURL: PropTypes.string.isRequired
 }
 
 export default PlateLocator

--- a/feedingwebapp/src/Pages/Home/VideoFeed.jsx
+++ b/feedingwebapp/src/Pages/Home/VideoFeed.jsx
@@ -1,11 +1,12 @@
 // React Imports
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 // PropTypes is used to validate that the used props are in fact passed to this Component
 import PropTypes from 'prop-types'
 
 // Local Imports
 import { CAMERA_FEED_TOPIC, REALSENSE_WIDTH, REALSENSE_HEIGHT } from '../Constants'
 import { useWindowSize } from '../../helpers'
+import { useROS, subscribeToROSTopic, unsubscribeFromROSTopic } from '../../ros/ros_helpers'
 
 /**
  * Takes in an imageWidth and imageHeight, and returns a width and height that
@@ -76,6 +77,46 @@ const VideoFeed = (props) => {
   const [imgWidth, setImgWidth] = useState(0)
   const [imgHeight, setImgHeight] = useState(0)
   const [scaleFactor, setScaleFactor] = useState(0.0)
+  // Store the latest image to render
+  const [latestRenderedImg, setLatestRenderedImg] = useState(null)
+
+  /**
+   * Connect to ROS, if not already connected. Put this in useRef to avoid
+   * re-connecting upon re-renders.
+   */
+  const ros = useRef(useROS().ros)
+  // Store the latest image timestamp in a ref to avoid re-generating cameraCallback
+  const latestImageTimestamp = useRef(null)
+
+  /**
+   * Subscribe to the image topic.
+   */
+  const cameraCallback = useCallback(
+    (message) => {
+      // console.log('Got camera message', message)
+      if (!latestImageTimestamp.current || props.updateRateHz <= 0) {
+        setLatestRenderedImg(message)
+      } else {
+        let currTime = message.header.stamp.sec + message.header.stamp.nanosec * 1e-9
+        if (currTime - latestImageTimestamp.current >= 1.0 / props.updateRateHz) {
+          setLatestRenderedImg(message)
+          latestImageTimestamp.current = currTime
+        }
+      }
+    },
+    [latestImageTimestamp, setLatestRenderedImg, props.updateRateHz]
+  )
+  useEffect(() => {
+    let topic = subscribeToROSTopic(ros.current, props.topic, 'sensor_msgs/CompressedImage', cameraCallback)
+    /**
+     * In practice, because the values passed in in the second argument of
+     * useEffect will not change on re-renders, this return statement will
+     * only be called when the component unmounts.
+     */
+    return () => {
+      unsubscribeFromROSTopic(topic, cameraCallback)
+    }
+  }, [cameraCallback, props.topic])
 
   // Callback to resize the image based on the parent width and height
   const resizeImage = useCallback(() => {
@@ -145,7 +186,7 @@ const VideoFeed = (props) => {
   // Render the component
   return (
     <img
-      src={`${props.webVideoServerURL}/stream?topic=${props.topic}&width=${imgWidth}&height=${imgHeight}&type=${props.type}`}
+      src={`data:image/jpeg;base64,${latestRenderedImg ? latestRenderedImg.data : ''}`}
       alt='Live video feed from the robot'
       style={{
         width: imgWidth,
@@ -161,8 +202,6 @@ const VideoFeed = (props) => {
 VideoFeed.propTypes = {
   // The ref to the parent DOM element. Null if the component is not yet mounted
   parent: PropTypes.object.isRequired,
-  // The URL of the video feed
-  webVideoServerURL: PropTypes.string.isRequired,
   // The margins around the video feed
   marginTop: PropTypes.number.isRequired,
   marginBottom: PropTypes.number.isRequired,
@@ -170,8 +209,8 @@ VideoFeed.propTypes = {
   marginRight: PropTypes.number.isRequired,
   // The topic of the video feed
   topic: PropTypes.string.isRequired,
-  // The type of the video feed
-  type: PropTypes.string.isRequired,
+  // The rate at which to update the video feed, in Hz
+  updateRateHz: PropTypes.number.isRequired,
   /**
    * An optional callback function for when the user clicks on the video feed.
    * This function should take in two parameters, `x` and `y`, which are the
@@ -182,7 +221,7 @@ VideoFeed.propTypes = {
 }
 VideoFeed.defaultProps = {
   topic: CAMERA_FEED_TOPIC,
-  type: 'ros_compressed'
+  updateRateHz: 10
 }
 
 export default VideoFeed

--- a/feedingwebapp/src/Pages/Home/VideoFeed.jsx
+++ b/feedingwebapp/src/Pages/Home/VideoFeed.jsx
@@ -107,14 +107,21 @@ const VideoFeed = (props) => {
     [latestImageTimestamp, setLatestRenderedImg, props.updateRateHz]
   )
   useEffect(() => {
+    console.log('subscribing to img topic')
     let topic = subscribeToROSTopic(ros.current, props.topic, 'sensor_msgs/CompressedImage', cameraCallback)
+    const cleanup = () => {
+      console.log('unsubscribing from img topic')
+      unsubscribeFromROSTopic(topic, cameraCallback)
+    }
+    window.addEventListener('beforeunload', cleanup)
     /**
      * In practice, because the values passed in in the second argument of
      * useEffect will not change on re-renders, this return statement will
      * only be called when the component unmounts.
      */
     return () => {
-      unsubscribeFromROSTopic(topic, cameraCallback)
+      window.removeEventListener('beforeunload', cleanup)
+      cleanup()
     }
   }, [cameraCallback, props.topic])
 

--- a/feedingwebapp/src/buttons/MaskButton.jsx
+++ b/feedingwebapp/src/buttons/MaskButton.jsx
@@ -31,7 +31,6 @@ function MaskButton(props) {
   // Get the properties
   let buttonSize = props.buttonSize
   let imgSrc = props.imgSrc
-  let imgSize = props.imgSize
   let maskSrc = props.maskSrc
   let invertMask = props.invertMask
   let maskScaleFactor = props.maskScaleFactor
@@ -67,15 +66,11 @@ function MaskButton(props) {
         >
           <img
             src={imgSrc}
-            alt='Live video feed from the robot'
+            alt='Robot camera view'
             style={{
-              width: imgSize.width,
-              height: imgSize.height,
+              width: maskBoundingBox.width * maskScaleFactor,
+              height: maskBoundingBox.height * maskScaleFactor,
               display: 'block',
-              margin: '-'.concat(
-                maskBoundingBox.y_offset * maskScaleFactor,
-                'px 0 0 -'.concat(maskBoundingBox.x_offset * maskScaleFactor, 'px')
-              ),
               pointerEvents: 'none'
             }}
           />
@@ -106,11 +101,6 @@ MaskButton.propTypes = {
   }).isRequired,
   // The image source URL
   imgSrc: PropTypes.string.isRequired,
-  // The image size
-  imgSize: PropTypes.shape({
-    width: PropTypes.number.isRequired,
-    height: PropTypes.number.isRequired
-  }).isRequired,
   // The mask source URL
   maskSrc: PropTypes.string.isRequired,
   // Whether or not to invert the mask


### PR DESCRIPTION
## Description

### Issues

1. The web app often doesn't show a camera feed when returning to Bite Selection, if your phone falls asleep during Bite Selection, or if you put your phone on sleep (e.g., press the power button) during Bite Selection.
    1. Further, sometimes even if it does render an image, it is a very old image (e.g., there is lots of latency).
2. Bite Selection overlays the mask on top of the **live video feed** for every mask (3 currently), hence maintaining 4 independent live video streams at once.

### Design Considerations

1. This post provides [an overview of 5 ways to stream videos for robots](https://transitiverobotics.com/blog/streaming-video-from-robots), and the pros/cons of each.
    1. As documented in that post, latency/lag is a well-known issue with `web_video_server` because it guarantees delivery of every packet. The only way to avoid it is to move away from `web_video_server`.
    2. My hunch about why it doesn't show the image is that either React or the browser caches some elements of the page layout and therefore do not attempt to reload the `web_video_server` URL. Or maybe it thinks the stream is still open, but `web_video_server` has closed the stream, Either way, changing the URL the web app is rendering should address this.
    3. Although in theory `web_video_server` supports video compression (e.g., h264 / vp8), in practice I hadn't been able to get them to work. The types I was able to get to work, `mjpeg` and `ros_compressed` essentially stream individual images anyway, nixing the video compression benefit of `web_video_server`.
    4. Hence, I decided to move away from `web_video_server` and towards sending and rendering individual `CompressedImage` messages in the app. **This should not require any more bandwidth than our existing approach, and should address the latency and blank image**.
    5. However, based on the linked post and Vinitha's experience with the Stretch robot, WebRTC will likely have lower latency and lower bandwidth. This is particularly important, because when running the app with [network and CPU throttling](https://www.wikihow.com/Throttle-Your-Browser-for-Testing#:~:text=Select%20an%20option%20from%20the%20%22No%20throttling%22%20menu.&text=Here%2C%20you'll%20find%20two,6%20times%20slower%20than%20normal.), the image doesn't render (nor does it get feedback). Hence, we should look into whether WebRTC will address that, and consider switching to WebRTC that for our web app.
2. Since [`ada_feeding`#141](https://github.com/personalrobotics/ada_feeding/pull/141), SegmentFromPoint now returns the RGB image, so the web app can overlay that with the mask, instead of the whole video feed.

### Solution
See 1.iv above.

## Testing

### Setup

Sim via EC2:
- [x] Pull the latest code on EC2
- [x] Re-build the workspace
- [x] In separate terminals, load:
    - [x] `ros2 launch feeding_web_app_ros2_test feeding_web_app_dummy_nodes_launch.xml`
    - [x] `ros2 run ada_feeding_perception republisher --ros-args --params-file src/ada_feeding/ada_feeding_perception/config/republisher.yaml`
    - [x] `cd src/feeding_web_interface/feedingwebapp/; npm start`

Real:
- [ ] Pull the latest code on `lovelace`. (Note: `pymoveit2` has a new main branch, `amaln/scale_collision_meshes`)
- [ ] Start the feeding as documented in the [wiki](https://github.com/personalrobotics/pr_docs/wiki/ADA) and [README](https://github.com/personalrobotics/ada_feeding/tree/ros2-devel/ada_feeding).

### Tests

- [x] Sim (https://bit.ly/ada_web_app_2)
    - [x] **Recreate old errors**: Without the code in this branch (i.e., using the old web app code), do the below steps and verify that you see some or all of the following errors: video feed not rendering (i.e., showing up as white), video feed rendering but frozen, video feed rendering but laggy.
        - [x] Do a complete nominal run-through of a bite and then return to bite selection. Do this at least twice. You should see one or more of the above issues.
        - [x] On the bite selection screen, let your phone go to sleep. After 5-10 secs, re-open your phone to the browser. You should see one or more of the above issues.
        - [x] On the bite selection screen, put your phone to sleep (e.g., pushing the power button). Wait, reopen, and look for errors.
        - [x] On the btie selection screen, go back to your app's home screen (e.g., move the app into the background). Wait, reopen, and look for errors.
    - [x] **Pull the code in this branch**
    - [x] Redo the above steps. Verify that there are no errors.
- [x] Real
    - [x] **Recreate old errors**: Without the code in this branch (i.e., using the old web app code), do the below steps and verify that you see some or all of the following errors: video feed not rendering (i.e., showing up as white), video feed rendering but frozen, video feed rendering but laggy.
        - [x] Do a complete nominal run-through of a bite and then return to bite selection. Do this at least twice. You should see one or more of the above issues.
        - [x] On the bite selection screen, let your phone go to sleep. After 5-10 secs, re-open your phone to the browser. You should see one or more of the above issues.
        - [x] On the bite selection screen, put your phone to sleep (e.g., pushing the power button). Wait, reopen, and look for errors.
        - [x] On the btie selection screen, go back to your app's home screen (e.g., move the app into the background). Wait, reopen, and look for errors.
    - [ ] **Pull the code in this branch**
    - [ ] Redo the 4 above checks on both wifi networks. Verify that there are no errors.
        - [ ] Phone is on `Lovelace-2.4G`
        - [ ] Phone is on `Lovelace-5G`

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [x] Format Python code by running `python3 -m black .` in the top-level of this repository
- [x] Thoroughly test your code's functionality, including unintended uses.
- [N/A] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [N/A] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
