### PR TITLE
Allow users to move back from staging configuration

### DIFF
--- a/feedingwebapp/src/Pages/Home/MealStates/DetectingFace.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/DetectingFace.jsx
@@ -36,16 +36,20 @@ const DetectingFace = (props) => {
   const setFaceDetectionAutoContinue = useGlobalState((state) => state.setFaceDetectionAutoContinue)
   // Get icon image for move to mouth
   let moveToMouthImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingToMouth]
+  let moveToRestingImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingToRestingPosition]
+  let moveAbovePlateImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingAbovePlate]
   // Flag to check if the current orientation is portrait
   const isPortrait = useMediaQuery({ query: '(orientation: portrait)' })
   // Indicator of how to arrange screen elements based on orientation
   let dimension = isPortrait ? 'column' : 'row'
+  let otherDimension = isPortrait ? 'row' : 'column'
   // Font size for text
-  let textFontSize = isPortrait ? '3vh' : '3vw'
-  let buttonWidth = isPortrait ? '30vh' : '30vw'
-  let buttonHeight = isPortrait ? '20vh' : '20vw'
-  let iconWidth = isPortrait ? '28vh' : '28vw'
-  let iconHeight = isPortrait ? '18vh' : '18vw'
+  let textFontSize = 3
+  let buttonWidth = 30
+  let buttonHeight = 20
+  let iconWidth = 28
+  let iconHeight = 18
+  let sizeSuffix = isPortrait ? 'vh' : 'vw'
   // The min and max distance from the camera to the face for the face to be
   // conidered valid. NOTE: This must match the values in the MoveToMouth tree.
   const min_face_distance = 0.4
@@ -69,6 +73,26 @@ const DetectingFace = (props) => {
   const moveToMouthCallback = useCallback(() => {
     console.log('Transitioning to R_MovingToMouth')
     setMealState(MEAL_STATE.R_MovingToMouth)
+    // Set mouth detected to false for the next time this screen comes up
+    setMouthDetected(false)
+  }, [setMealState, setMouthDetected])
+
+  /**
+   * Callback function for proceeding to move to the resting position.
+   */
+  const moveToRestingCallback = useCallback(() => {
+    console.log('Transitioning to R_MovingToRestingPosition')
+    setMealState(MEAL_STATE.R_MovingToRestingPosition)
+    // Set mouth detected to false for the next time this screen comes up
+    setMouthDetected(false)
+  }, [setMealState, setMouthDetected])
+
+  /**
+   * Callback function for proceeding to move above the plate.
+   */
+  const moveAbovePlateCallback = useCallback(() => {
+    console.log('Transitioning to R_MovingAbovePlate')
+    setMealState(MEAL_STATE.R_MovingAbovePlate)
     // Set mouth detected to false for the next time this screen comes up
     setMouthDetected(false)
   }, [setMealState, setMouthDetected])
@@ -160,7 +184,7 @@ const DetectingFace = (props) => {
             width: '100%'
           }}
         >
-          <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+          <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize.toString() + sizeSuffix }}>
             <input
               name='faceDetectionAutoContinue'
               type='checkbox'
@@ -179,7 +203,7 @@ const DetectingFace = (props) => {
             width: '100%'
           }}
         >
-          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}>
+          <View style={{ flex: 5, alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}>
             <View
               style={{
                 flex: 1,
@@ -189,7 +213,7 @@ const DetectingFace = (props) => {
                 height: '100%'
               }}
             >
-              <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+              <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize.toString() + sizeSuffix }}>
                 {mouthDetected ? 'Mouth detected!' : 'Waiting to detect mouth...'}
               </p>
             </View>
@@ -214,9 +238,9 @@ const DetectingFace = (props) => {
               />
             </View>
           </View>
-          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}>
-            <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
-              {mouthDetected ? 'Continue' : 'Continue without detecting mouth'}
+          <View style={{ flex: 3, alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}>
+            <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize.toString() + sizeSuffix }}>
+              {mouthDetected ? 'Continue' : 'Continue without detection'}
             </p>
             {/* Icon to move to mouth position */}
             <Button
@@ -224,24 +248,104 @@ const DetectingFace = (props) => {
               className='mx-2 mb-2 btn-huge'
               size='lg'
               onClick={moveToMouthCallback}
-              style={{ width: buttonWidth, height: buttonHeight }}
+              style={{
+                width: buttonWidth.toString() + sizeSuffix,
+                height: buttonHeight.toString() + sizeSuffix,
+                display: 'flex',
+                justifyContent: 'center',
+                alignContent: 'center'
+              }}
             >
-              <img src={moveToMouthImage} alt='move_to_mouth_image' className='center' style={{ width: iconWidth, height: iconHeight }} />
+              <img
+                src={moveToMouthImage}
+                alt='move_to_mouth_image'
+                className='center'
+                style={{ width: iconWidth.toString() + sizeSuffix, height: iconHeight.toString() + sizeSuffix }}
+              />
             </Button>
+          </View>
+          <View
+            style={{
+              flex: 2,
+              flexDirection: otherDimension,
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '100%',
+              height: '100%'
+            }}
+          >
+            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}>
+              <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: (textFontSize * 0.66).toString() + sizeSuffix }}>
+                Move to Resting
+              </p>
+              {/* Icon to move to mouth position */}
+              <Button
+                variant='warning'
+                className='mx-2 mb-2 btn-huge'
+                size='lg'
+                onClick={moveToRestingCallback}
+                style={{
+                  width: (buttonWidth / 2).toString() + sizeSuffix,
+                  height: (buttonHeight / 2).toString() + sizeSuffix,
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignContent: 'center'
+                }}
+              >
+                <img
+                  src={moveToRestingImage}
+                  alt='move_to_resting_image'
+                  className='center'
+                  style={{ width: (iconWidth / 2).toString() + sizeSuffix, height: (iconHeight / 2).toString() + sizeSuffix }}
+                />
+              </Button>
+            </View>
+            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}>
+              <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: (textFontSize * 0.66).toString() + sizeSuffix }}>
+                Move Above Plate
+              </p>
+              {/* Icon to move to mouth position */}
+              <Button
+                variant='warning'
+                className='mx-2 mb-2 btn-huge'
+                size='lg'
+                onClick={moveAbovePlateCallback}
+                style={{
+                  width: (buttonWidth / 2).toString() + sizeSuffix,
+                  height: (buttonHeight / 2).toString() + sizeSuffix,
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignContent: 'center'
+                }}
+              >
+                <img
+                  src={moveAbovePlateImage}
+                  alt='move_above_plate_image'
+                  className='center'
+                  style={{ width: (iconWidth / 2).toString() + sizeSuffix, height: (iconHeight / 2).toString() + sizeSuffix }}
+                />
+              </Button>
+            </View>
           </View>
         </View>
       </>
     )
   }, [
     dimension,
+    otherDimension,
     margin,
     mouthDetected,
     moveToMouthCallback,
+    moveToRestingCallback,
+    moveAbovePlateCallback,
     moveToMouthImage,
+    moveToRestingImage,
+    moveAbovePlateImage,
     props.webVideoServerURL,
     textFontSize,
     buttonHeight,
     buttonWidth,
+    sizeSuffix,
     iconHeight,
     iconWidth,
     faceDetectionAutoContinue,


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

Currently, once the robot/app gets to the staging configuration (`R_DetectingFace` in the app), the user *must* continue to their mouth. However, there are multiple cases where they won't want to, e.g.,
1. From the resting configuration, the user wanted to go back above the plate but clicked the wrong button.
2. `MoveToMouth` returns failure, but it is actually at the user's mouth. At this point, the user must click "Back" to go back, but then the "DetectingFace" screen needs to allow them to go back.

This PR adds two additional buttons to the `R_DetectingFace` page, to move to the resting configuration and to move back to the above plate configuration.

![Screenshot 2023-12-21 at 9 32 21 AM](https://github.com/personalrobotics/feeding_web_interface/assets/8277986/8d0ff0e7-6e08-4bb1-a53c-45c9fc0345ba)
The above image shows the screen before this PR.

![Screenshot 2023-12-21 at 9 31 48 AM](https://github.com/personalrobotics/feeding_web_interface/assets/8277986/8c4f34f3-a4e9-4de7-a060-14da7f01acfc)
The above image shows the screen after this PR.

## Explain how this pull request was tested, including but not limited to the below checkmarks.

- [x] Setup:
    - [x] `ros2 launch feeding_web_app_ros2_test feeding_web_app_dummy_nodes_launch.xml`
    - [x] `ros2 run ada_feeding_perception republisher --ros-args --params-file src/ada_feeding/ada_feeding_perception/config/republisher.yaml`
    - [x] `cd src/feeding_web_interface/feedingwebapp/; npm start`
- [x] Testing:
    - [x] Navigate to the Detecting Face page. Press each of the below buttons and verify that everything works as expected.
        - [x] Continue
        - [x] Move to Resting
        - [x] Move Above Plate
    - [x] On the DetectingFace page, try it with multiple different devices, orientations, and sizes. Some guidelines are [here](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md).

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [N/A] Format Python code by running `python3 -m black .` in the top-level of this repository
- [x] Thoroughly test your code's functionality, including unintended uses.
- [see above] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [x] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
