### PR TITLE
Temporary fix for video latency

### DIFF
--- a/feeding_web_app_ros2_test/launch/feeding_web_app_dummy_nodes_launch.xml
+++ b/feeding_web_app_ros2_test/launch/feeding_web_app_dummy_nodes_launch.xml
@@ -23,7 +23,7 @@
       <remap from="~/camera_info" to="/camera/color/camera_info"/>
       <remap from="~/aligned_depth/camera_info" to="/camera/aligned_depth_to_color/camera_info"/>
       <param name="fps" value="30"/>
-      <param name="rgb_path" value="$(find-pkg-share feeding_web_app_ros2_test)/../data/2022_11_01_ada_picks_up_carrots_camera_compressed_ft_tf.mp4"/>
+      <param name="rgb_path" value="$(find-pkg-share feeding_web_app_ros2_test)/../data/above_plate_1_rgb.jpg"/>
       <param name="depth_path" value="$(find-pkg-share feeding_web_app_ros2_test)/../data/above_plate_1_depth.png"/>
     </node>
   </group>

--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -48,10 +48,10 @@ NON_MOVING_STATES.add(MEAL_STATE.U_PostMeal)
 export { NON_MOVING_STATES }
 
 // The names of the ROS topic(s)
-export const CAMERA_FEED_TOPIC = '/local/camera/color/image_raw/compressed'
+export const CAMERA_FEED_TOPIC = '/local/camera/color/image_raw/compressed/low_hz'
 export const FACE_DETECTION_TOPIC = '/face_detection'
 export const FACE_DETECTION_TOPIC_MSG = 'ada_feeding_msgs/FaceDetection'
-export const FACE_DETECTION_IMG_TOPIC = '/face_detection_img/compressed'
+export const FACE_DETECTION_IMG_TOPIC = '/face_detection_img/compressed/low_hz'
 
 // States from which, if they fail, it is NOT okay for the user to retry the
 // same action.

--- a/feedingwebapp/src/Pages/Home/MealStates/DetectingFace.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/DetectingFace.jsx
@@ -43,9 +43,9 @@ const DetectingFace = () => {
   // Font size for text
   let textFontSize = 3
   let buttonWidth = 30
-  let buttonHeight = 20
+  let buttonHeight = 18
   let iconWidth = 28
-  let iconHeight = 18
+  let iconHeight = 16
   let sizeSuffix = isPortrait ? 'vh' : 'vw'
   // The min and max distance from the camera to the face for the face to be
   // conidered valid. NOTE: This must match the values in the MoveToMouth tree.

--- a/feedingwebapp/src/Pages/Home/VideoFeed.jsx
+++ b/feedingwebapp/src/Pages/Home/VideoFeed.jsx
@@ -241,7 +241,7 @@ VideoFeed.propTypes = {
 }
 VideoFeed.defaultProps = {
   topic: CAMERA_FEED_TOPIC,
-  updateRateHz: 10,
+  updateRateHz: 3,
   resubscribeRateHz: 0.1
 }
 


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

Joint PR with [`ada_feeding`#151](https://github.com/personalrobotics/ada_feeding/pull/151)

Although #106 improved video streaming by replacing the dependency on `web_video_server` with direct subscription to compressed images, the latency of this approach depends on the device. On a desktop computer, the video stream has 1-3 sec latency, but on an iPhone 11, it has increasing latency that gets into the tens of seconds.

Looking into it, the most likely reason for this is that [`roslibjs` uses EventEmitter2's `emit` event](https://github.com/personalrobotics/roslibjs/blob/af51b1550d4cc5241e19010ff2c4f980610f64b3/src/core/Topic.js#L79), which is synchronous. Thus, even if the subscriber on the ROS side has no queue, a queue builds up on the web app side.

The best solution to this, as documented [here](https://transitiverobotics.com/blog/streaming-video-from-robots/), is to implement WebRTC peer-to-peer streaming between the robot and web app. That is documented in issue #112 . 

However, given the learning curve and time involved in implementing WebRTC, this PR and its affiliated PR [`ada_feeding`#151](https://github.com/personalrobotics/ada_feeding/pull/151) introduces a _**temporary**_ fix to the problem, in the following ways:
1. Rate-limits the publication of image topics that the web app subscribes to to 3 Hz. (parameter set both in `ada_feeding_perception/config/republisher.yaml` and in `VideoFeed.jsx`)
2. Every 10 seconds, have the web app unsubscribe and re-subscribe to the topic, to clear any backlog. (parameter set in `VideoFeed.jsx`)

Note that these parameters can be tuned to find a subjectively optimal setting.

## Explain how this pull request was tested, including but not limited to the below checkmarks.

- [x] Pull the 2 PRs and re-build.
- [x] Start the robot code and the web app.
- [x] Go to bite selection, move your hand in and out of the camera, verify that the latency is not more than 1-2 secs.
- [x] Go to the `DetectingFace` page, move your head around in front of the camera, verify that the latency is not more than 1-2 secs.

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [N/A] Format Python code by running `python3 -m black .` in the top-level of this repository
- [x] Thoroughly test your code's functionality, including unintended uses.
- [N/A] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [N/A] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
