### PR TITLE
Small Fixes to WebRTC

### DIFF
--- a/feedingwebapp/src/robot/RobotVideoStreams.jsx
+++ b/feedingwebapp/src/robot/RobotVideoStreams.jsx
@@ -6,6 +6,14 @@ import PropTypes from 'prop-types'
 import { ROBOT_COMPRESSED_IMG_TOPICS } from '../Pages/Constants'
 import VideoStream from './VideoStream'
 
+/**
+ * Renders all the video streams from the robot.
+ *
+ * NOTE: This page *must* be rendered on the robot, otherwise it will have
+ * incredible lag.
+ *
+ * @param {string} webrtcURL - The URL of the webrtc signalling server.
+ */
 function RobotVideoStreams(props) {
   console.log('Rendering RobotVideoStreams', ROBOT_COMPRESSED_IMG_TOPICS)
   return (

--- a/feedingwebapp/src/robot/VideoStream.jsx
+++ b/feedingwebapp/src/robot/VideoStream.jsx
@@ -7,6 +7,17 @@ import { useROS, subscribeToROSTopic, unsubscribeFromROSTopic } from '../ros/ros
 import { createPeerConnection } from '../webrtc/webrtc_helpers'
 import { REALSENSE_WIDTH, REALSENSE_HEIGHT } from '../Pages/Constants'
 
+/**
+ * Renders a video stream from the robot.
+ *
+ * NOTE: This page *must* be rendered on the robot, otherwise it will have
+ * incredible lag.
+ *
+ * @param {string} webrtcURL - The URL of the webrtc signalling server.
+ * @param {string} topic - The topic to subscribe to.
+ *
+ * @returns {object} A canvas element that displays the video stream.
+ */
 function VideoStream(props) {
   const canvas = useRef(null)
   const img = useMemo(() => document.createElement('img'), [])

--- a/feedingwebapp/src/webrtc/webrtc_helpers.js
+++ b/feedingwebapp/src/webrtc/webrtc_helpers.js
@@ -2,6 +2,16 @@
 
 import axios from 'axios'
 
+/**
+ * Creates a peer connection to the given url and topic. This is intended to work with
+ * the server in server.js.
+ *
+ * @param {string} url The url of the server to connect to.
+ * @param {string} topic The topic to subscribe to.
+ * @param {function} onTrackAdded The callback function to call when a track is added.
+ * @param {function} onConnectionEnd The callback function to call when the connection ends.
+ * @returns {object} The RTCPeerConnection.
+ */
 export function createPeerConnection(url, topic, onTrackAdded, onConnectionEnd) {
   try {
     const peerConnection = new RTCPeerConnection({

--- a/feedingwebapp/start_robot_browser.js
+++ b/feedingwebapp/start_robot_browser.js
@@ -21,7 +21,7 @@ if (process.argv.length > 2) {
   ///////////////////////////////////////////////
 
   const browser = await chromium.launch({
-    headless: false, // default is true
+    headless: true, // default is true
     ignoreHTTPSErrors: true, // avoid ERR_CERT_COMMON_NAME_INVALID
     defaultViewport: null,
     args: [


### PR DESCRIPTION
This PR makes the following small changes to the WebRTC implementation in #112 :

1. Make the robot browser headless. (Hopefully, this will remove the need for the fake screen before launching the robot browser documented in the wiki).
2. Add comments to functions without it