### PR TITLE
Make `server.js` delete old peer connections on the same IP

### DIFF
--- a/feedingwebapp/src/Pages/Home/VideoFeed.jsx
+++ b/feedingwebapp/src/Pages/Home/VideoFeed.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 // Local Imports
 import { CAMERA_FEED_TOPIC, REALSENSE_WIDTH, REALSENSE_HEIGHT } from '../Constants'
 import { useWindowSize } from '../../helpers'
-import { createPeerConnection } from '../../webrtc/webrtc_helpers'
+import { createPeerConnection, closePeerConnection } from '../../webrtc/webrtc_helpers'
 
 /**
  * Takes in an imageWidth and imageHeight, and returns a width and height that
@@ -100,7 +100,7 @@ const VideoFeed = (props) => {
     peer.addTransceiver('video', { direction: 'recvonly' })
 
     return () => {
-      peer.close()
+      closePeerConnection(peer)
     }
   }, [props.topic, props.webrtcURL, videoRef])
 

--- a/feedingwebapp/src/webrtc/webrtc_helpers.js
+++ b/feedingwebapp/src/webrtc/webrtc_helpers.js
@@ -53,7 +53,7 @@ export function createPeerConnection(url, topic, onTrackAdded, onConnectionEnd) 
       if (peerConnection.connectionState === 'failed' || peerConnection.connectionState === 'disconnected') {
         console.error(peerConnection.connectionState, 'Resetting the PeerConnection')
         if (onConnectionEnd) onConnectionEnd()
-        createPeerConnection()
+        // peerConnection = createPeerConnection(url, topic, onTrackAdded, onConnectionEnd)
       }
       console.log('peerConnection.onconnectionstatechange', peerConnection.connectionState)
     }
@@ -67,5 +67,20 @@ export function createPeerConnection(url, topic, onTrackAdded, onConnectionEnd) 
   } catch (err) {
     console.error('Failed to create PeerConnection, exception: ' + err.message)
     return
+  }
+}
+
+/**
+ * Closes the given peer connection.
+ * @param {object} peerConnection The RTCPeerConnection to close.
+ */
+export function closePeerConnection(peerConnection) {
+  if (!peerConnection) return
+  console.log('Closing RTCPeerConnection', peerConnection)
+  if (peerConnection.connectionState !== 'closed') {
+    const senders = peerConnection.getSenders()
+    senders.forEach((sender) => peerConnection.removeTrack(sender))
+    peerConnection.close()
+    console.log('Closed RTCPeerConnection')
   }
 }


### PR DESCRIPTION
Before this PR, `server.js` created a new peer connection for every new registered publisher/subscriber. This was intentional, to allow multiple devices to simultaneously register to the robot's video stream (e.g., to test latency). However, this also means that throughout the course of the meal, more and more peer connections are created, which hugely increases the CPU utilization of `server.js` (we saw it go up to 500%).

This PR addresses that. When a new subscription or publishing request comes, if there was already an open peer for that IP address, the server first closes that peer before creating the new one.

Testing: On lovelace:
- [ ] Start `server.js`
- [ ] Start/restart `start_robot_browser.js` several times. Verify that CPU utilization for `server.js` stays roughly the same.
- [ ] Load the web app on another device. Load and reload a video stream (e.g., refreshing the bite selection page). Verify that CPU utilization for `server.js` stays roughly the same.
- [ ] Open a new tab on that device. Verify that the old tab stops updating but the new tab keeps updating.
- [ ] Load the web app on a different device. Verify that both media streams are updating.