### PR TITLE
Override AutoContinue if moving back from mouth

### DIFF
--- a/feedingwebapp/server.js
+++ b/feedingwebapp/server.js
@@ -24,82 +24,90 @@ app.use(bodyParser.urlencoded({ extended: true }))
 app.use(cors())
 
 app.post('/subscribe', async ({ body }, res) => {
-  console.log('got subscriber on IP', body.ip, 'for topic', body.topic)
+  try {
+    console.log('got subscriber on IP', body.ip, 'for topic', body.topic)
 
-  // Configure the peer connection
-  const peer = new webrtc.RTCPeerConnection({
-    iceServers: [
-      {
-        urls: 'stun:stun1.l.google.com:19302'
-      }
-    ]
-  })
+    // Configure the peer connection
+    const peer = new webrtc.RTCPeerConnection({
+      iceServers: [
+        {
+          urls: 'stun:stun1.l.google.com:19302'
+        }
+      ]
+    })
 
-  // Close any old peers on the same IP address
-  const topic = body.topic
-  const key = body.ip + ':' + topic
-  if (key in subscribePeers && subscribePeers[key] && subscribePeers[key].connectionState !== 'closed') {
-    const senders = subscribePeers[key].getSenders()
-    senders.forEach((sender) => subscribePeers[key].removeTrack(sender))
-    subscribePeers[key].close()
+    // Close any old peers on the same IP address
+    const topic = body.topic
+    const key = body.ip + ':' + topic
+    if (key in subscribePeers && subscribePeers[key] && subscribePeers[key].connectionState !== 'closed') {
+      const senders = subscribePeers[key].getSenders()
+      senders.forEach((sender) => subscribePeers[key].removeTrack(sender))
+      subscribePeers[key].close()
+    }
+    subscribePeers[key] = peer
+
+    const desc = new webrtc.RTCSessionDescription(body.sdp)
+    await peer.setRemoteDescription(desc)
+
+    // Add the publisher's video stream to the subscriber's peer connection
+    if (topic in senderStream) {
+      senderStream[topic].getTracks().forEach((track) => peer.addTrack(track, senderStream[topic]))
+    }
+
+    // Create an answer to the publisher's offer
+    const answer = await peer.createAnswer()
+    await peer.setLocalDescription(answer)
+    const payload = {
+      sdp: peer.localDescription
+    }
+
+    // Send the answer to the publisher
+    res.json(payload)
+  } catch (err) {
+    console.error('Failed to process subscriber, exception: ' + err.message)
   }
-  subscribePeers[key] = peer
-
-  const desc = new webrtc.RTCSessionDescription(body.sdp)
-  await peer.setRemoteDescription(desc)
-
-  // Add the publisher's video stream to the subscriber's peer connection
-  if (topic in senderStream) {
-    senderStream[topic].getTracks().forEach((track) => peer.addTrack(track, senderStream[topic]))
-  }
-
-  // Create an answer to the publisher's offer
-  const answer = await peer.createAnswer()
-  await peer.setLocalDescription(answer)
-  const payload = {
-    sdp: peer.localDescription
-  }
-
-  // Send the answer to the publisher
-  res.json(payload)
 })
 
 app.post('/publish', async ({ body }, res) => {
-  console.log('got publisher on IP', body.ip, 'for topic', body.topic)
+  try {
+    console.log('got publisher on IP', body.ip, 'for topic', body.topic)
 
-  // Configure the peer connection
-  const peer = new webrtc.RTCPeerConnection({
-    iceServers: [
-      {
-        urls: 'stun:stun1.l.google.com:19302'
-      }
-    ]
-  })
+    // Configure the peer connection
+    const peer = new webrtc.RTCPeerConnection({
+      iceServers: [
+        {
+          urls: 'stun:stun1.l.google.com:19302'
+        }
+      ]
+    })
 
-  // Close any old peers on the same IP address
-  const topic = body.topic
-  const key = body.ip + ':' + topic
-  if (key in publishPeers && publishPeers[key] && publishPeers[key].connectionState !== 'closed') {
-    const senders = publishPeers[key].getSenders()
-    senders.forEach((sender) => publishPeers[key].removeTrack(sender))
-    publishPeers[key].close()
+    // Close any old peers on the same IP address
+    const topic = body.topic
+    const key = body.ip + ':' + topic
+    if (key in publishPeers && publishPeers[key] && publishPeers[key].connectionState !== 'closed') {
+      const senders = publishPeers[key].getSenders()
+      senders.forEach((sender) => publishPeers[key].removeTrack(sender))
+      publishPeers[key].close()
+    }
+    publishPeers[key] = peer
+
+    // Send the publisher's video stream to all subscribers on that topic
+    peer.ontrack = (e) => handleTrackEvent(e, topic)
+
+    // Create an answer to the publisher's offer
+    const desc = new webrtc.RTCSessionDescription(body.sdp)
+    await peer.setRemoteDescription(desc)
+    const answer = await peer.createAnswer()
+    await peer.setLocalDescription(answer)
+    const payload = {
+      sdp: peer.localDescription
+    }
+
+    // Send the answer to the publisher
+    res.json(payload)
+  } catch (err) {
+    console.error('Failed to process publisher, exception: ' + err.message)
   }
-  publishPeers[key] = peer
-
-  // Send the publisher's video stream to all subscribers on that topic
-  peer.ontrack = (e) => handleTrackEvent(e, topic)
-
-  // Create an answer to the publisher's offer
-  const desc = new webrtc.RTCSessionDescription(body.sdp)
-  await peer.setRemoteDescription(desc)
-  const answer = await peer.createAnswer()
-  await peer.setLocalDescription(answer)
-  const payload = {
-    sdp: peer.localDescription
-  }
-
-  // Send the answer to the publisher
-  res.json(payload)
 })
 
 function handleTrackEvent(e, topic) {

--- a/feedingwebapp/src/Pages/GlobalState.jsx
+++ b/feedingwebapp/src/Pages/GlobalState.jsx
@@ -103,11 +103,13 @@ export const SETTINGS_STATE = {
  */
 export const useGlobalState = create(
   persist(
-    (set) => ({
+    (set, get) => ({
       // The current app page
       appPage: APP_PAGE.Home,
       // The app's current meal state
       mealState: MEAL_STATE.U_PreMeal,
+      // The app's previous meal state
+      prevMealState: null,
       // The timestamp when the robot transitioned to its current meal state
       mealStateTransitionTime: Date.now(),
       // The currently displayed settings page
@@ -152,6 +154,7 @@ export const useGlobalState = create(
         set(() => {
           let retval = {
             mealState: mealState,
+            prevMealState: get().mealState,
             mealStateTransitionTime: Date.now(),
             biteTransferPageAtFace: false // Reset this flag when the meal state changes
           }

--- a/feedingwebapp/src/Pages/Home/MealStates/DetectingFace.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/DetectingFace.jsx
@@ -22,6 +22,7 @@ const DetectingFace = (props) => {
   // Keep track of whether a mouth has been detected or not
   const [mouthDetected, setMouthDetected] = useState(false)
   // Get the relevant global variables
+  const prevMealState = useGlobalState((state) => state.prevMealState)
   const setMealState = useGlobalState((state) => state.setMealState)
   const setMoveToMouthActionGoal = useGlobalState((state) => state.setMoveToMouthActionGoal)
   const faceDetectionAutoContinue = useGlobalState((state) => state.faceDetectionAutoContinue)
@@ -84,11 +85,14 @@ const DetectingFace = (props) => {
         face_detection: message
       })
       // Automatically move on to the next stage if a face is detected
-      if (faceDetectionAutoContinue) {
+      // If the app got to this screen after moving away from the user's mouth,
+      // don't auto-continue. Only do so if it gets to this page from
+      // R_MovingToStagingConfiguration
+      if (faceDetectionAutoContinue && prevMealState !== MEAL_STATE.R_MovingFromMouth) {
         moveToMouthCallback()
       }
     },
-    [faceDetectionAutoContinue, moveToMouthCallback, setMoveToMouthActionGoal]
+    [faceDetectionAutoContinue, moveToMouthCallback, prevMealState, setMoveToMouthActionGoal]
   )
 
   /** Get the full page view


### PR DESCRIPTION
This PR overrides auto-continue if the robot arrived at `DetectingFace` through the `MoveFromMouth` state. This is to avoid the case where the user mistakenly presses back, and then it automatically moves to their mouth.

- [x] Check auto-continue, go to detecting face, verify that it continues.
- [x] From BiteDone, go back to staging config, verify it doesn't auto-continue.
- [x] Pause MoveToMouth and go back, verify it doesn't auto-continue.

This PR also adds better error handling to the WebRTC server.

***

**Before creating a pull request**

- [x] Format React code with `npm run format`

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
