### PR TITLE
Call AcquisitionReport service after food-on-fork question

### DIFF
--- a/feedingwebapp/package-lock.json
+++ b/feedingwebapp/package-lock.json
@@ -16,6 +16,7 @@
         "axios": "^1.6.5",
         "body-parser": "^1.20.2",
         "bootstrap": "^5.1.3",
+        "caniuse-lite": "^1.0.30001579",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "mdb-react-ui-kit": "^3.0.0",
@@ -7520,9 +7521,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001487",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
-      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
+      "version": "1.0.30001579",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
+      "integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
       "funding": [
         {
           "type": "opencollective",

--- a/feedingwebapp/package.json
+++ b/feedingwebapp/package.json
@@ -11,6 +11,7 @@
     "axios": "^1.6.5",
     "body-parser": "^1.20.2",
     "bootstrap": "^5.1.3",
+    "caniuse-lite": "^1.0.30001579",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "mdb-react-ui-kit": "^3.0.0",

--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -109,6 +109,8 @@ ROS_SERVICE_NAMES[MEAL_STATE.R_DetectingFace] = {
 export { ROS_SERVICE_NAMES }
 export const CLEAR_OCTOMAP_SERVICE_NAME = 'clear_octomap'
 export const CLEAR_OCTOMAP_SERVICE_TYPE = 'std_srvs/srv/Empty'
+export const ACQUISITION_REPORT_SERVICE_NAME = 'ada_feeding_action_select/action_report'
+export const ACQUISITION_REPORT_SERVICE_TYPE = 'ada_feeding_msgs/srv/AcquisitionReport'
 export const GET_PARAMETERS_SERVICE_NAME = 'ada_feeding_action_servers/get_parameters'
 export const GET_PARAMETERS_SERVICE_TYPE = 'rcl_interfaces/srv/GetParameters'
 export const SET_PARAMETERS_SERVICE_NAME = 'ada_feeding_action_servers/set_parameters'

--- a/feedingwebapp/src/Pages/GlobalState.jsx
+++ b/feedingwebapp/src/Pages/GlobalState.jsx
@@ -121,6 +121,8 @@ export const useGlobalState = create(
       // message received from the face detection node where a
       // face was detected and within the distance bounds of the camera.
       moveToMouthActionGoal: null,
+      // Last RobotMotion action response
+      lastMotionActionResponse: null,
       // Whether or not the currently-executing robot motion was paused by the user
       paused: false,
       // Flag to indicate robot motion trough teleoperation interface
@@ -170,6 +172,10 @@ export const useGlobalState = create(
       setBiteAcquisitionActionGoal: (biteAcquisitionActionGoal) =>
         set(() => ({
           biteAcquisitionActionGoal: biteAcquisitionActionGoal
+        })),
+      setLastMotionActionResponse: (lastMotionActionResponse) =>
+        set(() => ({
+          lastMotionActionResponse: lastMotionActionResponse
         })),
       setMoveToMouthActionGoal: (moveToMouthActionGoal) =>
         set(() => ({

--- a/feedingwebapp/src/Pages/Home/MealStates/BiteAcquisitionCheck.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/BiteAcquisitionCheck.jsx
@@ -2,6 +2,7 @@
 import React, { useCallback } from 'react'
 import Button from 'react-bootstrap/Button'
 import { useMediaQuery } from 'react-responsive'
+import { toast } from 'react-toastify'
 import { View } from 'react-native'
 
 // Local Imports
@@ -37,6 +38,7 @@ const BiteAcquisitionCheck = () => {
    */
   const acquisitionSuccess = useCallback(() => {
     console.log('acquisitionSuccess')
+    toast.info('Reporting Food Acquisition Success!')
     setMealState(MEAL_STATE.R_MovingToStagingConfiguration)
   }, [setMealState])
 
@@ -46,6 +48,7 @@ const BiteAcquisitionCheck = () => {
    */
   const acquisitionFailure = useCallback(() => {
     console.log('acquisitionFailure')
+    toast.info('Reporting Food Acquisition Failure.')
     setMealState(MEAL_STATE.R_MovingAbovePlate)
   }, [setMealState])
 

--- a/feedingwebapp/src/Pages/Home/MealStates/RobotMotion.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/RobotMotion.jsx
@@ -146,7 +146,7 @@ const RobotMotion = (props) => {
         setActionStatus({
           actionStatus: ROS_ACTION_STATUS_SUCCEED
         })
-        setLastMotionActionResponse(response)
+        setLastMotionActionResponse(response.values)
         robotMotionDone()
       } else {
         if (

--- a/feedingwebapp/src/Pages/Home/MealStates/RobotMotion.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/RobotMotion.jsx
@@ -63,6 +63,9 @@ const RobotMotion = (props) => {
   const paused = useGlobalState((state) => state.paused)
   const setPaused = useGlobalState((state) => state.setPaused)
 
+  // Setter for last motion action response
+  const setLastMotionActionResponse = useGlobalState((state) => state.setLastMotionActionResponse)
+
   /**
    * Connect to ROS, if not already connected. Put this in useRef to avoid
    * re-connecting upon re-renders.
@@ -143,6 +146,7 @@ const RobotMotion = (props) => {
         setActionStatus({
           actionStatus: ROS_ACTION_STATUS_SUCCEED
         })
+        setLastMotionActionResponse(response)
         robotMotionDone()
       } else {
         if (
@@ -163,7 +167,7 @@ const RobotMotion = (props) => {
         }
       }
     },
-    [setActionStatus, setPaused, robotMotionDone]
+    [setLastMotionActionResponse, setActionStatus, setPaused, robotMotionDone]
   )
 
   /**


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

After any robot motion, the last reported action response is cached as part of the GlobalState.

After Bite Acquisition, this response is used to construct a call to AcquisitionReport, which updates the robot's online learning policy based on success or failure of the action.

Additionally, added a toast to the screen upon selecting whether to re-aquire or not.

## Explain how this pull request was tested, including but not limited to the below checkmarks.

Tested on real with the `ros2-devel` branch of https://github.com/personalrobotics/ada_feeding

No python code changes: black not run

No change to user flow, so that box is not checked.

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [ ] Format Python code by running `python3 -m black .` in the top-level of this repository
- [ ] Thoroughly test your code's functionality, including unintended uses.
- [ ] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [ ] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
