### PR TITLE
Centralize dependencies using `rosdep`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repository contains code for the feeding web app. The app itself is in `fee
 
 ## Setup
 
-See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/amaln/rosdeps/README.md).
+See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/README.md).

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 This repository contains code for the feeding web app. The app itself is in `feedingwebapp`. ROS nodes used to test the app are in `feeding_web_app_ros2_test`, and messages for those ROS nodes are in `feeding_web_app_ros2_msgs`. Each directory contains its own README.
 
-## ROS Dependencies
-- [ROS2 Humble](https://docs.ros.org/en/humble/Installation.html)
-- [PRL fork of rosbridge_suite](https://github.com/personalrobotics/rosbridge_suite). This fork enables rosbridge_suite to communicate with ROS2 actions.
-- [ada_feeding (branch: `ros2-devel`)](https://github.com/personalrobotics/ada_feeding/tree/ros2-devel).
-- [web_video_server (branch: `ros2`)](https://github.com/RobotWebTools/web_video_server/tree/ros2)
-    - Dependency: `ros-humble-async-web-server-cpp`
-    - Dependency: `ros-humble-vision-opencv`
-    
-All these repositories of `feeding_web_interface`, `ada_feeding`, `async_web_server_cpp`, `vision_opencv`, `web_video_server`, and `PRL fork of rosbridge_suite` as mentioned above should be downloaded using `git clone ...` in the "src" folder inside the ROS2 workspace. Please follow the [Ubuntu (Debian) tutorial](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html) for ROS2 installation in Ubuntu 22, which will automatically lead to creation of "src" folder in ROS2 workspace. To access hidden `.env` file in Ubuntu to change the debug flag's value, press Ctrl + H in the `feeding_web_interface` folder. 
+## Setup
+
+See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/amaln/rosdeps/README.md).

--- a/feeding_web_app_ros2_test/README.md
+++ b/feeding_web_app_ros2_test/README.md
@@ -2,12 +2,9 @@
 
 This directory contains all the ROS2 nodes that are used to test the web app. This includes: (1) dummy nodes that have the same interface as robot nodes, but actually just sleep; and (2) nodes for the "Test ROS" page of the web app, which demonstrates how to use our ROS helper functions.
 
-## Dependencies
-- [ROS2 Humble](https://docs.ros.org/en/humble/Installation.html)
-- Python dependencies:
-```
-python3 -m pip install numpy pymongo shapely tornado
-```
+## Setup
+
+See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/amaln/rosdeps/README.md).
 
 ## Usage
 

--- a/feeding_web_app_ros2_test/README.md
+++ b/feeding_web_app_ros2_test/README.md
@@ -4,7 +4,7 @@ This directory contains all the ROS2 nodes that are used to test the web app. Th
 
 ## Setup
 
-See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/amaln/rosdeps/README.md).
+See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/README.md).
 
 ## Usage
 

--- a/feeding_web_app_ros2_test/feeding_web_app_ros2_test/MoveFromMouth.py
+++ b/feeding_web_app_ros2_test/feeding_web_app_ros2_test/MoveFromMouth.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from ada_feeding_msgs.action import MoveTo
+from feeding_web_app_ros2_test.MoveToDummy import MoveToDummy
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    move_from_mouth = MoveToDummy("MoveFromMouth", MoveTo)
+
+    # Use a MultiThreadedExecutor to enable processing goals concurrently
+    executor = MultiThreadedExecutor()
+
+    rclpy.spin(move_from_mouth, executor=executor)
+
+
+if __name__ == "__main__":
+    main()

--- a/feeding_web_app_ros2_test/launch/feeding_web_app_dummy_nodes_launch.xml
+++ b/feeding_web_app_ros2_test/launch/feeding_web_app_dummy_nodes_launch.xml
@@ -49,6 +49,8 @@
     <node pkg="feeding_web_app_ros2_test" exec="MoveToStagingConfiguration" name="MoveToStagingConfiguration"/>
     <!-- Motion: The MoveToMouth action -->
     <node pkg="feeding_web_app_ros2_test" exec="MoveToMouth" name="MoveToMouth"/>
+    <!-- Motion: The MoveFromMouth action -->
+    <node pkg="feeding_web_app_ros2_test" exec="MoveFromMouth" name="MoveFromMouth"/>
     <!-- Motion: The MoveFromMouthToStagingConfiguration action -->
     <node pkg="feeding_web_app_ros2_test" exec="MoveFromMouthToStagingConfiguration" name="MoveFromMouthToStagingConfiguration"/>
     <!-- Motion: The MoveFromMouthToAbovePlate action -->

--- a/feeding_web_app_ros2_test/setup.py
+++ b/feeding_web_app_ros2_test/setup.py
@@ -40,6 +40,7 @@ setup(
             "MoveToRestingPosition = feeding_web_app_ros2_test.MoveToRestingPosition:main",
             "MoveToStagingConfiguration = feeding_web_app_ros2_test.MoveToStagingConfiguration:main",
             "MoveToMouth = feeding_web_app_ros2_test.MoveToMouth:main",
+            "MoveFromMouth = feeding_web_app_ros2_test.MoveFromMouth:main",
             "MoveFromMouthToStagingConfiguration = feeding_web_app_ros2_test.MoveFromMouthToStagingConfiguration:main",
             "MoveFromMouthToAbovePlate = feeding_web_app_ros2_test.MoveFromMouthToAbovePlate:main",
             "MoveFromMouthToRestingPosition = feeding_web_app_ros2_test.MoveFromMouthToRestingPosition:main",

--- a/feedingwebapp/README.md
+++ b/feedingwebapp/README.md
@@ -4,7 +4,7 @@ This directory contains the web app that users use to interact with the robot-as
 
 ## Setup
 
-See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/amaln/rosdeps/README.md).
+See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/README.md).
 
 ## Overview
 The _nominal_ user flow for this web app can be seen below.

--- a/feedingwebapp/README.md
+++ b/feedingwebapp/README.md
@@ -2,18 +2,20 @@
 
 This directory contains the web app that users use to interact with the robot-assisted feeding system. This readme includes an overview and contribution guidelines, while [TechDocumentation.md](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp/TechDocumentation.md) includes more specific documentation of the technical aspects of the app.
 
-## Overview
-The overall user flow for this robot can be seen below.
+## Setup
 
-![newWebAppWorkflow](https://user-images.githubusercontent.com/26337328/223597500-5e520b7a-eb2b-45ad-b9e8-91fec1bdeba4.jpg)
-(Last Updated 2023/03/07)
+See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/amaln/rosdeps/README.md).
+
+## Overview
+The _nominal_ user flow for this web app can be seen below.
+
+![Screenshot 2024-02-14 at 8 23 06 PM](https://github.com/personalrobotics/feeding_web_interface/assets/8277986/d944de8b-6d5a-4839-8d1b-1bc4d6f5db70)
+(Last Updated 2024/02/14)
+
+<!-- ![newWebAppWorkflow](https://user-images.githubusercontent.com/26337328/223597500-5e520b7a-eb2b-45ad-b9e8-91fec1bdeba4.jpg)
+(Last Updated 2023/03/07) -->
 <!-- ![Web App State Machine](https://user-images.githubusercontent.com/8277986/191333326-c71a1765-475c-40f6-87da-a79b7c73e0ee.png) 
 (Last Updated 2022/09/20) -->
-
-## Dependencies
-- [Node.js](https://nodejs.org/en/download/package-manager)
-- [`serve` must be globally installed](https://create-react-app.dev/docs/deployment/) (ideally with `sudo`): `sudo npm install -g serve`
-- [`pm2` must be globally installed](https://pm2.keymetrics.io/docs/usage/quick-start/): `npm install pm2@latest -g`
 
 ## Getting Started in Computer
 


### PR DESCRIPTION
1. Add `MoveFromMouth` dummy action.
2. For all setup, point to [the top-level `ada_feeding` README](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/README.md).