### PR TITLE
Added FoodOnFork Detection to Web App

### DIFF
--- a/feeding_web_app_ros2_test/feeding_web_app_ros2_test/FaceDetection.py
+++ b/feeding_web_app_ros2_test/feeding_web_app_ros2_test/FaceDetection.py
@@ -70,7 +70,6 @@ class FaceDetectionNode(Node):
             self.camera_callback,
             1,
         )
-        self.subscription  # prevent unused variable warning
 
         # Create the publishers
         self.publisher_results = self.create_publisher(

--- a/feeding_web_app_ros2_test/feeding_web_app_ros2_test/FoodOnForkDetection.py
+++ b/feeding_web_app_ros2_test/feeding_web_app_ros2_test/FoodOnForkDetection.py
@@ -69,7 +69,9 @@ class FoodOnForkDetectionNode(Node):
         self.get_logger().info("Incoming service request. turn_on: %s" % (request.data))
         if request.data:
             # Reset counters
-            self.num_consecutive_images_without_food = 0
+            self.num_consecutive_images_without_food = (
+                self.food_on_fork_detection_interval
+            )  # Start predicting FoF
             self.num_consecutive_images_with_food = 0
             # Turn on food-on-fork detection
             self.is_on_lock.acquire()

--- a/feeding_web_app_ros2_test/feeding_web_app_ros2_test/FoodOnForkDetection.py
+++ b/feeding_web_app_ros2_test/feeding_web_app_ros2_test/FoodOnForkDetection.py
@@ -32,7 +32,9 @@ class FoodOnForkDetectionNode(Node):
         # Internal variables to track when food should be detected
         self.food_on_fork_detection_interval = food_on_fork_detection_interval
         self.num_images_with_food = num_images_with_food
-        self.num_consecutive_images_without_food = 0
+        self.num_consecutive_images_without_food = (
+            self.food_on_fork_detection_interval
+        )  # Start predicting FoF
         self.num_consecutive_images_with_food = 0
 
         # Keeps track of whether food on fork detection is on or not

--- a/feeding_web_app_ros2_test/feeding_web_app_ros2_test/FoodOnForkDetection.py
+++ b/feeding_web_app_ros2_test/feeding_web_app_ros2_test/FoodOnForkDetection.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+from ada_feeding_msgs.msg import FoodOnForkDetection
+from std_srvs.srv import SetBool
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import CompressedImage
+from threading import Lock
+
+
+class FoodOnForkDetectionNode(Node):
+    def __init__(
+        self,
+        food_on_fork_detection_interval=90,
+        num_images_with_food=90,
+    ):
+        """
+        Initializes the FoodOnForkDetection node, which exposes a SetBool
+        service that can be used to toggle the food on fork detection on or off and
+        publishes information  to the /food_on_fork_detection topic when food-on-fork
+        detection is on.
+
+        After food_on_fork_detection_interval images without food, this dummy function
+        detects food for num_images_with_food frames.
+
+        Parameters:
+        ----------
+        food_on_fork_detection_interval: The number of frames between each food detection.
+        num_images_with_food: The number of frames that must have a food in them.
+        """
+        super().__init__("food_on_fork_detection")
+
+        # Internal variables to track when food should be detected
+        self.food_on_fork_detection_interval = food_on_fork_detection_interval
+        self.num_images_with_food = num_images_with_food
+        self.num_consecutive_images_without_food = 0
+        self.num_consecutive_images_with_food = 0
+
+        # Keeps track of whether food on fork detection is on or not
+        self.is_on = False
+        self.is_on_lock = Lock()
+
+        # Create the service
+        self.srv = self.create_service(
+            SetBool,
+            "toggle_food_on_fork_detection",
+            self.toggle_food_on_fork_detection_callback,
+        )
+
+        # Subscribe to the camera feed
+        self.subscription = self.create_subscription(
+            CompressedImage,
+            "camera/color/image_raw/compressed",
+            self.camera_callback,
+            1,
+        )
+
+        # Create the publishers
+        self.publisher_results = self.create_publisher(
+            FoodOnForkDetection, "food_on_fork_detection", 1
+        )
+
+    def toggle_food_on_fork_detection_callback(self, request, response):
+        """
+        Callback function for the SetBool service. Safely toggles
+        the food on fork detection on or off depending on the request.
+        """
+        self.get_logger().info("Incoming service request. turn_on: %s" % (request.data))
+        if request.data:
+            # Reset counters
+            self.num_consecutive_images_without_food = 0
+            self.num_consecutive_images_with_food = 0
+            # Turn on food-on-fork detection
+            self.is_on_lock.acquire()
+            self.is_on = True
+            self.is_on_lock.release()
+            response.success = True
+            response.message = "Succesfully turned food-on-fork detection on"
+        else:
+            self.is_on_lock.acquire()
+            self.is_on = False
+            self.is_on_lock.release()
+            response.success = True
+            response.message = "Succesfully turned food-on-fork detection off"
+        return response
+
+    def camera_callback(self, msg):
+        """
+        Callback function for the camera feed. If food-on-fork detection is on, this
+        function will detect food in the image and publish information about
+        them to the /food_on_fork_detection topic.
+        """
+        self.get_logger().debug("Received image")
+        self.is_on_lock.acquire()
+        is_on = self.is_on
+        self.is_on_lock.release()
+        if is_on:
+            # Update the number of consecutive images with/without a food
+            is_food_detected = False
+            if self.num_consecutive_images_with_food == self.num_images_with_food:
+                self.num_consecutive_images_without_food = 0
+                self.num_consecutive_images_with_food = 0
+            if (
+                self.num_consecutive_images_without_food
+                == self.food_on_fork_detection_interval
+            ):
+                # Detect food on the fork
+                self.num_consecutive_images_with_food += 1
+                is_food_detected = True
+            else:
+                # Don't detect food
+                self.num_consecutive_images_without_food += 1
+
+            # Publish the food-on-fork detection information
+            food_on_fork_detection_msg = FoodOnForkDetection()
+            food_on_fork_detection_msg.header = msg.header
+            food_on_fork_detection_msg.probability = 1.0 if is_food_detected else 0.0
+            food_on_fork_detection_msg.status = food_on_fork_detection_msg.SUCCESS
+            food_on_fork_detection_msg.message = (
+                "Food detected" if is_food_detected else "No food detected"
+            )
+            self.publisher_results.publish(food_on_fork_detection_msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    food_on_fork_detection = FoodOnForkDetectionNode()
+
+    rclpy.spin(food_on_fork_detection)
+
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/feeding_web_app_ros2_test/launch/feeding_web_app_dummy_nodes_launch.xml
+++ b/feeding_web_app_ros2_test/launch/feeding_web_app_dummy_nodes_launch.xml
@@ -4,6 +4,7 @@
   <arg name="run_web_bridge" default="true"  description="Whether to run rosbridge and web_video_server" />
   <arg name="run_food_detection" default="true" description="Whether to run the dummy food detectoion node" />
   <arg name="run_face_detection" default="true" description="Whether to run the dummy face detection node" />
+  <arg name="run_food_on_fork_detection" default="true" description="Whether to run the dummy food-on-fork detection node" />
   <arg name="run_real_sense" default="true" description="Whether to run the dummy RealSense node" />
   <arg name="run_motion" default="true"  description="Whether to run the dummy motion nodes" />
   <arg name="rgb_path" default="above_plate_2_rgb.jpg"  description="The path to the RGB image/video to publish from the dummy node, relative to this node's share/data folder." />
@@ -24,7 +25,7 @@
       <remap from="~/aligned_depth" to="/camera/aligned_depth_to_color/image_raw"/>
       <remap from="~/camera_info" to="/camera/color/camera_info"/>
       <remap from="~/aligned_depth/camera_info" to="/camera/aligned_depth_to_color/camera_info"/>
-      <param name="fps" value="30"/>
+      <param name="fps" value="15"/>
       <param name="rgb_path" value="$(find-pkg-share feeding_web_app_ros2_test)/../data/$(var rgb_path)"/>
       <param name="depth_path" value="$(find-pkg-share feeding_web_app_ros2_test)/../data/$(var depth_path)"/>
     </node>
@@ -38,6 +39,11 @@
   <group if="$(var run_face_detection)">
     <!-- Perception: The FaceDetection node -->
     <node pkg="feeding_web_app_ros2_test" exec="FaceDetection" name="FaceDetection"/>
+  </group>
+
+  <group if="$(var run_food_on_fork_detection)">
+    <!-- Perception: The FoodOnForkDetection node -->
+    <node pkg="feeding_web_app_ros2_test" exec="FoodOnForkDetection" name="FoodOnForkDetection"/>
   </group>
   
   <group if="$(var run_motion)">

--- a/feeding_web_app_ros2_test/setup.py
+++ b/feeding_web_app_ros2_test/setup.py
@@ -36,6 +36,7 @@ setup(
             "AcquireFoodClient = feeding_web_app_ros2_test.AcquireFoodClient:main",
             "DummyRealSense = feeding_web_app_ros2_test.DummyRealSense:main",
             "FaceDetection = feeding_web_app_ros2_test.FaceDetection:main",
+            "FoodOnForkDetection = feeding_web_app_ros2_test.FoodOnForkDetection:main",
             "MoveAbovePlate = feeding_web_app_ros2_test.MoveAbovePlate:main",
             "MoveToRestingPosition = feeding_web_app_ros2_test.MoveToRestingPosition:main",
             "MoveToStagingConfiguration = feeding_web_app_ros2_test.MoveToStagingConfiguration:main",

--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -112,6 +112,10 @@ ROS_SERVICE_NAMES[MEAL_STATE.U_BiteDone] = {
   serviceName: 'toggle_food_on_fork_detection',
   messageType: 'std_srvs/srv/SetBool'
 }
+ROS_SERVICE_NAMES[MEAL_STATE.U_BiteAcquisitionCheck] = {
+  serviceName: 'toggle_food_on_fork_detection',
+  messageType: 'std_srvs/srv/SetBool'
+}
 export { ROS_SERVICE_NAMES }
 export const CLEAR_OCTOMAP_SERVICE_NAME = 'clear_octomap'
 export const CLEAR_OCTOMAP_SERVICE_TYPE = 'std_srvs/srv/Empty'

--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -50,6 +50,8 @@ export const CAMERA_FEED_TOPIC = '/local/camera/color/image_raw/compressed'
 export const FACE_DETECTION_TOPIC = '/face_detection'
 export const FACE_DETECTION_TOPIC_MSG = 'ada_feeding_msgs/FaceDetection'
 export const FACE_DETECTION_IMG_TOPIC = '/face_detection_img/compressed'
+export const FOOD_ON_FORK_DETECTION_TOPIC = '/food_on_fork_detection'
+export const FOOD_ON_FORK_DETECTION_TOPIC_MSG = 'ada_feeding_msgs/FoodOnForkDetection'
 export const ROBOT_COMPRESSED_IMG_TOPICS = [CAMERA_FEED_TOPIC, FACE_DETECTION_IMG_TOPIC]
 
 // States from which, if they fail, it is NOT okay for the user to retry the
@@ -104,6 +106,10 @@ export { ROS_ACTIONS_NAMES }
 let ROS_SERVICE_NAMES = {}
 ROS_SERVICE_NAMES[MEAL_STATE.R_DetectingFace] = {
   serviceName: 'toggle_face_detection',
+  messageType: 'std_srvs/srv/SetBool'
+}
+ROS_SERVICE_NAMES[MEAL_STATE.U_BiteDone] = {
+  serviceName: 'toggle_food_on_fork_detection',
   messageType: 'std_srvs/srv/SetBool'
 }
 export { ROS_SERVICE_NAMES }

--- a/feedingwebapp/src/Pages/GlobalState.jsx
+++ b/feedingwebapp/src/Pages/GlobalState.jsx
@@ -76,27 +76,6 @@ export const SETTINGS_STATE = {
 }
 
 /**
- * The parameters that users can set (keys) and a list of human-readable values
- * they can take on.
- *   - stagingPosition: Discrete options for where the robot should wait until
- *     the user is ready.
- *   - biteInitiation: Options for the modality the user wants to use to tell
- *     the robot they are ready for a bite.
- *       - TODO: Make these checkboxes instead -- users should be able to
- *         enable multiple buttons if they so desire.
- *   - biteSelection: Options for how the user wants to tell the robot what food
- *     item they want next.
- *
- * TODO (amaln): When we connect this to ROS, each of these settings types and
- * value options will have to have corresponding rosparam names and value options.
- */
-// export const SETTINGS = {
-//   stagingPosition: ['In Front of Me', 'On My Right Side'],
-//   biteInitiation: ['Open Mouth', 'Say "I am Ready"', 'Press Button'],
-//   biteSelection: ['Name of Food', 'Click on Food']
-// }
-
-/**
  * useGlobalState is a hook to store and manipulate web app state that we want
  * to persist across re-renders and refreshes. It won't persist if cookies are
  * cleared.
@@ -129,6 +108,10 @@ export const useGlobalState = create(
       teleopIsMoving: false,
       // Flag to indicate whether to auto-continue after face detection
       faceDetectionAutoContinue: true,
+      // Flag to indicate whether to auto-continue after food-on-fork detection
+      biteDoneAutoContinue: false,
+      biteDoneAutoContinueSeconds: 5.0,
+      biteDoneAutoContinueProbabilityThreshold: 0.75,
       // Whether the settings bite transfer page is currently at the user's face
       // or not. This is in the off-chance that the mealState is not at the user's
       // face, the settings page is, and the user refreshes -- the page should
@@ -140,11 +123,6 @@ export const useGlobalState = create(
       mostRecentBiteDoneResponse: MEAL_STATE.R_DetectingFace,
       // How much the video on the Bite Selection page should be zoomed in.
       biteSelectionZoom: 1.0,
-
-      // Settings values
-      // stagingPosition: SETTINGS.stagingPosition[0],
-      // biteInitiation: SETTINGS.biteInitiation[0],
-      // biteSelection: SETTINGS.biteSelection[0],
 
       // Setters for global state
       setAppPage: (appPage) =>
@@ -196,6 +174,18 @@ export const useGlobalState = create(
         set(() => ({
           faceDetectionAutoContinue: faceDetectionAutoContinue
         })),
+      setBiteDoneAutoContinue: (biteDoneAutoContinue) =>
+        set(() => ({
+          biteDoneAutoContinue: biteDoneAutoContinue
+        })),
+      setBiteDoneAutoContinueSeconds: (biteDoneAutoContinueSeconds) =>
+        set(() => ({
+          biteDoneAutoContinueSeconds: biteDoneAutoContinueSeconds
+        })),
+      setBiteDoneAutoContinueProbabilityThreshold: (biteDoneAutoContinueProbabilityThreshold) =>
+        set(() => ({
+          biteDoneAutoContinueProbabilityThreshold: biteDoneAutoContinueProbabilityThreshold
+        })),
       setBiteTransferPageAtFace: (biteTransferPageAtFace) =>
         set(() => ({
           biteTransferPageAtFace: biteTransferPageAtFace
@@ -204,18 +194,6 @@ export const useGlobalState = create(
         set(() => ({
           biteSelectionZoom: biteSelectionZoom
         }))
-      // setStagingPosition: (stagingPosition) =>
-      //   set(() => ({
-      //     stagingPosition: stagingPosition
-      //   })),
-      // setBiteInitiation: (biteInitiation) =>
-      //   set(() => ({
-      //     biteInitiation: biteInitiation
-      //   })),
-      // setBiteSelection: (biteSelection) =>
-      //   set(() => ({
-      //     biteSelection: biteSelection
-      //   }))
     }),
     { name: 'ada_web_app_global_state' }
   )

--- a/feedingwebapp/src/Pages/GlobalState.jsx
+++ b/feedingwebapp/src/Pages/GlobalState.jsx
@@ -110,7 +110,7 @@ export const useGlobalState = create(
       faceDetectionAutoContinue: true,
       // Flag to indicate whether to auto-continue after food-on-fork detection
       biteDoneAutoContinue: false,
-      biteDoneAutoContinueSeconds: 5.0,
+      biteDoneAutoContinueSeconds: 3.0,
       biteDoneAutoContinueProbabilityThreshold: 0.25,
       // Whether the settings bite transfer page is currently at the user's face
       // or not. This is in the off-chance that the mealState is not at the user's

--- a/feedingwebapp/src/Pages/GlobalState.jsx
+++ b/feedingwebapp/src/Pages/GlobalState.jsx
@@ -111,7 +111,7 @@ export const useGlobalState = create(
       // Flag to indicate whether to auto-continue after food-on-fork detection
       biteDoneAutoContinue: false,
       biteDoneAutoContinueSeconds: 5.0,
-      biteDoneAutoContinueProbabilityThreshold: 0.75,
+      biteDoneAutoContinueProbabilityThreshold: 0.25,
       // Whether the settings bite transfer page is currently at the user's face
       // or not. This is in the off-chance that the mealState is not at the user's
       // face, the settings page is, and the user refreshes -- the page should

--- a/feedingwebapp/src/Pages/GlobalState.jsx
+++ b/feedingwebapp/src/Pages/GlobalState.jsx
@@ -108,10 +108,16 @@ export const useGlobalState = create(
       teleopIsMoving: false,
       // Flag to indicate whether to auto-continue after face detection
       faceDetectionAutoContinue: true,
-      // Flag to indicate whether to auto-continue after food-on-fork detection
+      // Flag to indicate whether to auto-continue in bite done after food-on-fork detection
       biteDoneAutoContinue: false,
-      biteDoneAutoContinueSeconds: 3.0,
-      biteDoneAutoContinueProbabilityThreshold: 0.25,
+      biteDoneAutoContinueSecs: 3.0,
+      biteDoneAutoContinueProbThresh: 0.25,
+      // Flags to indicate whether to auto-continue in bite acquisition check based on food-on-fork
+      // detection
+      biteAcquisitionCheckAutoContinue: false,
+      biteAcquisitionCheckAutoContinueSecs: 3.0,
+      biteAcquisitionCheckAutoContinueProbThreshLower: 0.25,
+      biteAcquisitionCheckAutoContinueProbThreshUpper: 0.75,
       // Whether the settings bite transfer page is currently at the user's face
       // or not. This is in the off-chance that the mealState is not at the user's
       // face, the settings page is, and the user refreshes -- the page should
@@ -178,13 +184,29 @@ export const useGlobalState = create(
         set(() => ({
           biteDoneAutoContinue: biteDoneAutoContinue
         })),
-      setBiteDoneAutoContinueSeconds: (biteDoneAutoContinueSeconds) =>
+      setBiteDoneAutoContinueSecs: (biteDoneAutoContinueSecs) =>
         set(() => ({
-          biteDoneAutoContinueSeconds: biteDoneAutoContinueSeconds
+          biteDoneAutoContinueSecs: biteDoneAutoContinueSecs
         })),
-      setBiteDoneAutoContinueProbabilityThreshold: (biteDoneAutoContinueProbabilityThreshold) =>
+      setBiteDoneAutoContinueProbThresh: (biteDoneAutoContinueProbThresh) =>
         set(() => ({
-          biteDoneAutoContinueProbabilityThreshold: biteDoneAutoContinueProbabilityThreshold
+          biteDoneAutoContinueProbThresh: biteDoneAutoContinueProbThresh
+        })),
+      setBiteAcquisitionCheckAutoContinue: (biteAcquisitionCheckAutoContinue) =>
+        set(() => ({
+          biteAcquisitionCheckAutoContinue: biteAcquisitionCheckAutoContinue
+        })),
+      setBiteAcquisitionCheckAutoContinueSecs: (biteAcquisitionCheckAutoContinueSecs) =>
+        set(() => ({
+          biteAcquisitionCheckAutoContinueSecs: biteAcquisitionCheckAutoContinueSecs
+        })),
+      setBiteAcquisitionCheckAutoContinueProbThreshLower: (biteAcquisitionCheckAutoContinueProbThreshLower) =>
+        set(() => ({
+          biteAcquisitionCheckAutoContinueProbThreshLower: biteAcquisitionCheckAutoContinueProbThreshLower
+        })),
+      setBiteAcquisitionCheckAutoContinueProbThreshUpper: (biteAcquisitionCheckAutoContinueProbThreshUpper) =>
+        set(() => ({
+          biteAcquisitionCheckAutoContinueProbThreshUpper: biteAcquisitionCheckAutoContinueProbThreshUpper
         })),
       setBiteTransferPageAtFace: (biteTransferPageAtFace) =>
         set(() => ({

--- a/feedingwebapp/src/Pages/Home/MealStates/BiteAcquisitionCheck.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/BiteAcquisitionCheck.jsx
@@ -360,7 +360,9 @@ const BiteAcquisitionCheck = () => {
             {biteAcquisitionCheckAutoContinue && prevMealState === MEAL_STATE.R_BiteAcquisition
               ? remainingSeconds === null
                 ? 'Checking for food on fork...'
-                : 'Moving away in ' + remainingSeconds + ' seconds'
+                : timerWasForFof.current
+                ? 'Moving to your face in ' + remainingSeconds + ' secs'
+                : 'Moving above plate in ' + remainingSeconds + ' secs'
               : ''}
           </p>
         </View>
@@ -380,6 +382,7 @@ const BiteAcquisitionCheck = () => {
     biteAcquisitionCheckAutoContinue,
     clearTimer,
     dimension,
+    prevMealState,
     readyForBiteButton,
     readyForBiteText,
     reacquireBiteButton,

--- a/feedingwebapp/src/Pages/Home/MealStates/BiteAcquisitionCheck.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/BiteAcquisitionCheck.jsx
@@ -1,5 +1,5 @@
 // React Imports
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useEffect, useState, useRef } from 'react'
 import Button from 'react-bootstrap/Button'
 import { useMediaQuery } from 'react-responsive'
 import { toast } from 'react-toastify'
@@ -9,16 +9,30 @@ import { View } from 'react-native'
 import '../Home.css'
 import { useGlobalState, MEAL_STATE } from '../../GlobalState'
 import { MOVING_STATE_ICON_DICT } from '../../Constants'
-import { useROS, createROSService, createROSServiceRequest } from '../../../ros/ros_helpers'
-import { ACQUISITION_REPORT_SERVICE_NAME, ACQUISITION_REPORT_SERVICE_TYPE } from '../../Constants'
+import { useROS, createROSService, createROSServiceRequest, subscribeToROSTopic, unsubscribeFromROSTopic } from '../../../ros/ros_helpers'
+import {
+  ACQUISITION_REPORT_SERVICE_NAME,
+  ACQUISITION_REPORT_SERVICE_TYPE,
+  FOOD_ON_FORK_DETECTION_TOPIC,
+  FOOD_ON_FORK_DETECTION_TOPIC_MSG,
+  ROS_SERVICE_NAMES
+} from '../../Constants'
 
 /**
  * The BiteAcquisitionCheck component appears after the robot has attempted to
  * acquire a bite, and asks the user whether it succeeded at acquiring the bite.
  */
 const BiteAcquisitionCheck = () => {
+  // Store the remining time before auto-continuing
+  const [remainingSeconds, setRemainingSeconds] = useState(null)
   // Get the relevant global variables
+  const prevMealState = useGlobalState((state) => state.prevMealState)
   const setMealState = useGlobalState((state) => state.setMealState)
+  const biteAcquisitionCheckAutoContinue = useGlobalState((state) => state.biteAcquisitionCheckAutoContinue)
+  const setBiteAcquisitionCheckAutoContinue = useGlobalState((state) => state.setBiteAcquisitionCheckAutoContinue)
+  const biteAcquisitionCheckAutoContinueSecs = useGlobalState((state) => state.biteAcquisitionCheckAutoContinueSecs)
+  const biteAcquisitionCheckAutoContinueProbThreshLower = useGlobalState((state) => state.biteAcquisitionCheckAutoContinueProbThreshLower)
+  const biteAcquisitionCheckAutoContinueProbThreshUpper = useGlobalState((state) => state.biteAcquisitionCheckAutoContinueProbThreshUpper)
   // Get icon image for move above plate
   let moveAbovePlateImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingAbovePlate]
   // Get icon image for move to mouth
@@ -45,6 +59,12 @@ const BiteAcquisitionCheck = () => {
    * Create the ROS Service Client for reporting success/failure
    */
   let acquisitionReportService = useRef(createROSService(ros.current, ACQUISITION_REPORT_SERVICE_NAME, ACQUISITION_REPORT_SERVICE_TYPE))
+  /**
+   * Create the ROS Service. This is created in local state to avoid re-creating
+   * it upon every re-render.
+   */
+  let { serviceName, messageType } = ROS_SERVICE_NAMES[MEAL_STATE.U_BiteAcquisitionCheck]
+  let toggleFoodOnForkDetectionService = useRef(createROSService(ros.current, serviceName, messageType))
 
   /**
    * Callback function for when the user indicates that the bite acquisition
@@ -85,6 +105,136 @@ const BiteAcquisitionCheck = () => {
     service.callService(request, (response) => console.log('Got acquisition report response', response))
     setMealState(MEAL_STATE.R_MovingAbovePlate)
   }, [lastMotionActionResponse, setMealState])
+
+  /*
+   * Create refs to store the interval for the food-on-fork detection timers.
+   * Note we need two timers, because the first timer set's remainingTime, whereas
+   * we can't set remainingTime in the second timer otherwise it will attempt to
+   * set state on an unmounted component.
+   **/
+  const timerWasForFof = useRef(null)
+  const timerRef = useRef(null)
+  const finalTimerRef = useRef(null)
+  const clearTimer = useCallback(() => {
+    console.log('Clearing timer')
+    if (finalTimerRef.current) {
+      clearInterval(finalTimerRef.current)
+      finalTimerRef.current = null
+    }
+    if (timerRef.current) {
+      clearInterval(timerRef.current)
+      timerRef.current = null
+      setRemainingSeconds(null)
+      timerWasForFof.current = null
+    }
+  }, [setRemainingSeconds, timerRef, timerWasForFof, finalTimerRef])
+
+  /**
+   * Subscribe to the ROS Topic with the food-on-fork detection result. This is
+   * created in local state to avoid re-creating it upon every re-render.
+   */
+  const foodOnForkDetectionCallback = useCallback(
+    (message) => {
+      console.log('Got food-on-fork detection message', message)
+      // Only auto-continue if the previous state was Bite Acquisition
+      if (biteAcquisitionCheckAutoContinue && prevMealState === MEAL_STATE.R_BiteAcquisition && message.status === 1) {
+        let callbackFn = null
+        if (message.probability < biteAcquisitionCheckAutoContinueProbThreshLower) {
+          console.log('No FoF. Auto-continuing in ', remainingSeconds, ' seconds')
+          if (timerWasForFof.current === true) {
+            clearTimer()
+          }
+          timerWasForFof.current = false
+          callbackFn = acquisitionFailure
+        } else if (message.probability > biteAcquisitionCheckAutoContinueProbThreshUpper) {
+          console.log('FoF. Auto-continuing in ', remainingSeconds, ' seconds')
+          if (timerWasForFof.current === false) {
+            clearTimer()
+          }
+          timerWasForFof.current = true
+          callbackFn = acquisitionSuccess
+        } else {
+          console.log('Not auto-continuing due to probability between thresholds')
+          clearTimer()
+        }
+        // Don't override an existing timer
+        if (!timerRef.current && callbackFn !== null) {
+          setRemainingSeconds(biteAcquisitionCheckAutoContinueSecs)
+          timerRef.current = setInterval(() => {
+            setRemainingSeconds((prev) => {
+              if (prev <= 1) {
+                clearTimer()
+                // In the remaining time, move above plate
+                finalTimerRef.current = setInterval(() => {
+                  clearInterval(finalTimerRef.current)
+                  callbackFn()
+                }, (prev - 1) * 1000)
+                return null
+              } else {
+                return prev - 1
+              }
+            })
+          }, 1000)
+        }
+      }
+    },
+    [
+      acquisitionSuccess,
+      acquisitionFailure,
+      biteAcquisitionCheckAutoContinue,
+      biteAcquisitionCheckAutoContinueProbThreshLower,
+      biteAcquisitionCheckAutoContinueProbThreshUpper,
+      biteAcquisitionCheckAutoContinueSecs,
+      finalTimerRef,
+      remainingSeconds,
+      clearTimer,
+      prevMealState,
+      setRemainingSeconds,
+      timerRef,
+      timerWasForFof
+    ]
+  )
+  useEffect(() => {
+    let topic = subscribeToROSTopic(
+      ros.current,
+      FOOD_ON_FORK_DETECTION_TOPIC,
+      FOOD_ON_FORK_DETECTION_TOPIC_MSG,
+      foodOnForkDetectionCallback
+    )
+    /**
+     * In practice, because the values passed in in the second argument of
+     * useEffect will not change on re-renders, this return statement will
+     * only be called when the component unmounts.
+     */
+    return () => {
+      unsubscribeFromROSTopic(topic, foodOnForkDetectionCallback)
+    }
+  }, [foodOnForkDetectionCallback])
+
+  /**
+   * Toggles food-on-fork detection on the first time this component is rendered,
+   * but not upon additional re-renders. See here for more details on how `useEffect`
+   * achieves this goal: https://stackoverflow.com/a/69264685
+   */
+  useEffect(() => {
+    // Create a service request
+    let request = createROSServiceRequest({ data: true })
+    // Call the service
+    let service = toggleFoodOnForkDetectionService.current
+    service.callService(request, (response) => console.log('Got toggle food on fork detection service response', response))
+
+    /**
+     * In practice, because the values passed in in the second argument of
+     * useEffect will not change on re-renders, this return statement will
+     * only be called when the component unmounts.
+     */
+    return () => {
+      // Create a service request
+      let request = createROSServiceRequest({ data: false })
+      // Call the service
+      service.callService(request, (response) => console.log('Got toggle food on fork detection service response', response))
+    }
+  }, [toggleFoodOnForkDetectionService])
 
   /**
    * Get the ready for bite text to render.
@@ -173,18 +323,71 @@ const BiteAcquisitionCheck = () => {
    */
   const fullPageView = useCallback(() => {
     return (
-      <View style={{ flex: 'auto', flexDirection: dimension, alignItems: 'center', justifyContent: 'center' }}>
-        <View style={{ flex: 5, alignItems: 'center', justifyContent: 'center' }}>
-          {readyForBiteText()}
-          {readyForBiteButton()}
+      <>
+        <View
+          style={{
+            flex: 1,
+            flexDirection: 'row',
+            justifyContent: 'center',
+            alignItems: 'center',
+            width: '100%'
+          }}
+        >
+          <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+            <input
+              name='biteAcquisitionCheckAutoContinue'
+              type='checkbox'
+              checked={biteAcquisitionCheckAutoContinue}
+              onChange={(e) => {
+                clearTimer()
+                setBiteAcquisitionCheckAutoContinue(e.target.checked)
+              }}
+              style={{ transform: 'scale(2.0)', verticalAlign: 'middle', marginRight: '15px' }}
+            />
+            Auto-continue
+          </p>
         </View>
-        <View style={{ flex: 5, alignItems: 'center', justifyContent: 'center' }}>
-          {reacquireBiteText()}
-          {reacquireBiteButton()}
+        <View
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '100%',
+            height: '100%'
+          }}
+        >
+          <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+            {biteAcquisitionCheckAutoContinue && prevMealState === MEAL_STATE.R_BiteAcquisition
+              ? remainingSeconds === null
+                ? 'Checking for food on fork...'
+                : 'Moving away in ' + remainingSeconds + ' seconds'
+              : ''}
+          </p>
         </View>
-      </View>
+        <View style={{ flex: 'auto', flexDirection: dimension, alignItems: 'center', justifyContent: 'center' }}>
+          <View style={{ flex: 5, alignItems: 'center', justifyContent: 'center' }}>
+            {readyForBiteText()}
+            {readyForBiteButton()}
+          </View>
+          <View style={{ flex: 5, alignItems: 'center', justifyContent: 'center' }}>
+            {reacquireBiteText()}
+            {reacquireBiteButton()}
+          </View>
+        </View>
+      </>
     )
-  }, [dimension, reacquireBiteButton, reacquireBiteText, readyForBiteButton, readyForBiteText])
+  }, [
+    biteAcquisitionCheckAutoContinue,
+    clearTimer,
+    dimension,
+    readyForBiteButton,
+    readyForBiteText,
+    reacquireBiteButton,
+    reacquireBiteText,
+    remainingSeconds,
+    setBiteAcquisitionCheckAutoContinue,
+    textFontSize
+  ])
 
   // Render the component
   return <>{fullPageView()}</>

--- a/feedingwebapp/src/Pages/Home/MealStates/BiteDone.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/BiteDone.jsx
@@ -96,7 +96,7 @@ const BiteDone = () => {
   const foodOnForkDetectionCallback = useCallback(
     (message) => {
       console.log('Got food-on-fork detection message', message)
-      if (biteDoneAutoContinue) {
+      if (biteDoneAutoContinue && message.status === 1) {
         if (message.probability < biteDoneAutoContinueProbabilityThreshold) {
           console.log('Auto-continuing in ', remainingSeconds, ' seconds')
           // Don't override an existing timer

--- a/feedingwebapp/src/Pages/Home/MealStates/BiteDone.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/BiteDone.jsx
@@ -97,7 +97,7 @@ const BiteDone = () => {
     (message) => {
       console.log('Got food-on-fork detection message', message)
       if (biteDoneAutoContinue) {
-        if (message.probability >= biteDoneAutoContinueProbabilityThreshold) {
+        if (message.probability < biteDoneAutoContinueProbabilityThreshold) {
           console.log('Auto-continuing in ', remainingSeconds, ' seconds')
           // Don't override an existing timer
           if (!timerRef.current) {

--- a/feedingwebapp/src/Pages/Home/MealStates/BiteDone.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/BiteDone.jsx
@@ -35,11 +35,12 @@ const BiteDone = () => {
   // Indicator of how to arrange screen elements based on orientation
   let dimension = isPortrait ? 'column' : 'row'
   // Font size for text
-  let textFontSize = isPortrait ? '3vh' : '2.5vw'
+  let textFontSize = isPortrait ? 3 : 2.5
+  let sizeSuffix = isPortrait ? 'vh' : 'vw'
   let buttonWidth = isPortrait ? '30vh' : '30vw'
-  let buttonHeight = isPortrait ? '20vh' : '20vw'
+  let buttonHeight = isPortrait ? '16vh' : '16vw'
   let iconWidth = isPortrait ? '28vh' : '28vw'
-  let iconHeight = isPortrait ? '18vh' : '18vw'
+  let iconHeight = isPortrait ? '14vh' : '14vw'
 
   /**
    * Callback function for when the user wants to move above plate.
@@ -201,7 +202,7 @@ const BiteDone = () => {
             width: '100%'
           }}
         >
-          <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+          <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize.toString() + sizeSuffix }}>
             <input
               name='biteDoneAutoContinue'
               type='checkbox'
@@ -212,13 +213,30 @@ const BiteDone = () => {
               }}
               style={{ transform: 'scale(2.0)', verticalAlign: 'middle', marginRight: '15px' }}
             />
-            Auto-continu{remainingSeconds === null ? 'e' : 'ing in ' + remainingSeconds + ' seconds'}
+            Auto-continue
+          </p>
+        </View>
+        <View
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '100%',
+            height: '100%'
+          }}
+        >
+          <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize.toString() + sizeSuffix }}>
+            {biteDoneAutoContinue
+              ? remainingSeconds === null
+                ? 'Waiting for the fork to be empty'
+                : 'Moving away in ' + remainingSeconds + ' seconds'
+              : ''}
           </p>
         </View>
         <View style={{ flex: 9, flexDirection: dimension, alignItems: 'center', justifyContent: 'center', width: '100%' }}>
           <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
             {/* Ask the user whether they want to move to above plate position */}
-            <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+            <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize.toString() + sizeSuffix }}>
               Move above plate
             </p>
             {/* Icon to move above plate */}
@@ -239,7 +257,7 @@ const BiteDone = () => {
           </View>
           <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
             {/* Ask the user whether they want to move to resting position */}
-            <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+            <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize.toString() + sizeSuffix }}>
               Rest to the side
             </p>
             {/* Icon to move to resting position */}
@@ -260,7 +278,7 @@ const BiteDone = () => {
           </View>
           <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
             {/* Ask the user whether they want to move to resting position */}
-            <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+            <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize.toString() + sizeSuffix }}>
               Move away from mouth
             </p>
             {/* Icon to move to resting position */}
@@ -298,7 +316,8 @@ const BiteDone = () => {
     remainingSeconds,
     clearTimer,
     setBiteDoneAutoContinue,
-    textFontSize
+    textFontSize,
+    sizeSuffix
   ])
 
   // Render the component

--- a/feedingwebapp/src/Pages/Home/MealStates/BiteDone.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/BiteDone.jsx
@@ -22,8 +22,8 @@ const BiteDone = () => {
   const setMealState = useGlobalState((state) => state.setMealState)
   const biteDoneAutoContinue = useGlobalState((state) => state.biteDoneAutoContinue)
   const setBiteDoneAutoContinue = useGlobalState((state) => state.setBiteDoneAutoContinue)
-  const biteDoneAutoContinueSeconds = useGlobalState((state) => state.biteDoneAutoContinueSeconds)
-  const biteDoneAutoContinueProbabilityThreshold = useGlobalState((state) => state.biteDoneAutoContinueProbabilityThreshold)
+  const biteDoneAutoContinueSecs = useGlobalState((state) => state.biteDoneAutoContinueSecs)
+  const biteDoneAutoContinueProbThresh = useGlobalState((state) => state.biteDoneAutoContinueProbThresh)
   // Get icon image for move above plate
   let moveAbovePlateImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingAbovePlate]
   // Get icon image for move to resting position
@@ -98,11 +98,11 @@ const BiteDone = () => {
     (message) => {
       console.log('Got food-on-fork detection message', message)
       if (biteDoneAutoContinue && message.status === 1) {
-        if (message.probability < biteDoneAutoContinueProbabilityThreshold) {
+        if (message.probability < biteDoneAutoContinueProbThresh) {
           console.log('Auto-continuing in ', remainingSeconds, ' seconds')
           // Don't override an existing timer
           if (!timerRef.current) {
-            setRemainingSeconds(biteDoneAutoContinueSeconds)
+            setRemainingSeconds(biteDoneAutoContinueSecs)
             timerRef.current = setInterval(() => {
               setRemainingSeconds((prev) => {
                 if (prev <= 1) {
@@ -127,8 +127,8 @@ const BiteDone = () => {
     },
     [
       biteDoneAutoContinue,
-      biteDoneAutoContinueProbabilityThreshold,
-      biteDoneAutoContinueSeconds,
+      biteDoneAutoContinueProbThresh,
+      biteDoneAutoContinueSecs,
       finalTimerRef,
       remainingSeconds,
       clearTimer,

--- a/feedingwebapp/src/Pages/Home/MealStates/BiteDone.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/BiteDone.jsx
@@ -1,13 +1,14 @@
 // React Imports
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import Button from 'react-bootstrap/Button'
 import { useMediaQuery } from 'react-responsive'
 import { View } from 'react-native'
 
 // Local Imports
+import { useROS, createROSService, createROSServiceRequest, subscribeToROSTopic, unsubscribeFromROSTopic } from '../../../ros/ros_helpers'
 import '../Home.css'
 import { useGlobalState, MEAL_STATE } from '../../GlobalState'
-import { MOVING_STATE_ICON_DICT } from '../../Constants'
+import { FOOD_ON_FORK_DETECTION_TOPIC, FOOD_ON_FORK_DETECTION_TOPIC_MSG, ROS_SERVICE_NAMES, MOVING_STATE_ICON_DICT } from '../../Constants'
 
 /**
  * The BiteDone component appears after the robot has moved to the user's mouth,
@@ -15,8 +16,14 @@ import { MOVING_STATE_ICON_DICT } from '../../Constants'
  * moving back to above plate.
  */
 const BiteDone = () => {
+  // Store the remining time before auto-continuing
+  const [remainingSeconds, setRemainingSeconds] = useState(null)
   // Get the relevant global variables
   const setMealState = useGlobalState((state) => state.setMealState)
+  const biteDoneAutoContinue = useGlobalState((state) => state.biteDoneAutoContinue)
+  const setBiteDoneAutoContinue = useGlobalState((state) => state.setBiteDoneAutoContinue)
+  const biteDoneAutoContinueSeconds = useGlobalState((state) => state.biteDoneAutoContinueSeconds)
+  const biteDoneAutoContinueProbabilityThreshold = useGlobalState((state) => state.biteDoneAutoContinueProbabilityThreshold)
   // Get icon image for move above plate
   let moveAbovePlateImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingAbovePlate]
   // Get icon image for move to resting position
@@ -55,79 +62,228 @@ const BiteDone = () => {
     setMealState(MEAL_STATE.R_MovingFromMouth, MEAL_STATE.R_DetectingFace)
   }, [setMealState])
 
+  /*
+   * Create refs to store the interval for the food-on-fork detection timers.
+   * Note we need two timers, because the first timer set's remainingTime, whereas
+   * we can't set remainingTime in the second timer otherwise it will attempt to
+   * set state on an unmounted component.
+   **/
+  const timerRef = useRef(null)
+  const finalTimerRef = useRef(null)
+  const clearTimer = useCallback(() => {
+    console.log('Clearing timer')
+    if (finalTimerRef.current) {
+      clearInterval(finalTimerRef.current)
+      finalTimerRef.current = null
+    }
+    if (timerRef.current) {
+      clearInterval(timerRef.current)
+      timerRef.current = null
+      setRemainingSeconds(null)
+    }
+  }, [setRemainingSeconds, timerRef])
+
+  /**
+   * Connect to ROS, if not already connected. Put this in useRef to avoid
+   * re-connecting upon re-renders.
+   */
+  const ros = useRef(useROS().ros)
+
+  /**
+   * Subscribe to the ROS Topic with the food-on-fork detection result. This is
+   * created in local state to avoid re-creating it upon every re-render.
+   */
+  const foodOnForkDetectionCallback = useCallback(
+    (message) => {
+      console.log('Got food-on-fork detection message', message)
+      if (biteDoneAutoContinue) {
+        if (message.probability >= biteDoneAutoContinueProbabilityThreshold) {
+          console.log('Auto-continuing in ', remainingSeconds, ' seconds')
+          // Don't override an existing timer
+          if (!timerRef.current) {
+            setRemainingSeconds(biteDoneAutoContinueSeconds)
+            timerRef.current = setInterval(() => {
+              setRemainingSeconds((prev) => {
+                if (prev <= 1) {
+                  clearTimer()
+                  // In the remaining time, move above plate
+                  finalTimerRef.current = setInterval(() => {
+                    clearInterval(finalTimerRef.current)
+                    moveAbovePlate()
+                  }, (prev - 1) * 1000)
+                  return null
+                } else {
+                  return prev - 1
+                }
+              })
+            }, 1000)
+          }
+        } else {
+          console.log('Not auto-continuing')
+          clearTimer()
+        }
+      }
+    },
+    [
+      biteDoneAutoContinue,
+      biteDoneAutoContinueProbabilityThreshold,
+      biteDoneAutoContinueSeconds,
+      finalTimerRef,
+      remainingSeconds,
+      clearTimer,
+      moveAbovePlate,
+      setRemainingSeconds,
+      timerRef
+    ]
+  )
+  useEffect(() => {
+    let topic = subscribeToROSTopic(
+      ros.current,
+      FOOD_ON_FORK_DETECTION_TOPIC,
+      FOOD_ON_FORK_DETECTION_TOPIC_MSG,
+      foodOnForkDetectionCallback
+    )
+    /**
+     * In practice, because the values passed in in the second argument of
+     * useEffect will not change on re-renders, this return statement will
+     * only be called when the component unmounts.
+     */
+    return () => {
+      unsubscribeFromROSTopic(topic, foodOnForkDetectionCallback)
+    }
+  }, [foodOnForkDetectionCallback])
+
+  /**
+   * Create the ROS Service. This is created in local state to avoid re-creating
+   * it upon every re-render.
+   */
+  let { serviceName, messageType } = ROS_SERVICE_NAMES[MEAL_STATE.U_BiteDone]
+  let toggleFoodOnForkDetectionService = useRef(createROSService(ros.current, serviceName, messageType))
+
+  /**
+   * Toggles food-on-fork detection on the first time this component is rendered,
+   * but not upon additional re-renders. See here for more details on how `useEffect`
+   * achieves this goal: https://stackoverflow.com/a/69264685
+   */
+  useEffect(() => {
+    // Create a service request
+    let request = createROSServiceRequest({ data: true })
+    // Call the service
+    let service = toggleFoodOnForkDetectionService.current
+    service.callService(request, (response) => console.log('Got toggle food on fork detection service response', response))
+
+    /**
+     * In practice, because the values passed in in the second argument of
+     * useEffect will not change on re-renders, this return statement will
+     * only be called when the component unmounts.
+     */
+    return () => {
+      // Create a service request
+      let request = createROSServiceRequest({ data: false })
+      // Call the service
+      service.callService(request, (response) => console.log('Got toggle food on fork detection service response', response))
+    }
+  }, [toggleFoodOnForkDetectionService])
+
   /** Get the full page view
    *
    * @returns {JSX.Element} the the full page view
    */
   const fullPageView = useCallback(() => {
     return (
-      <View style={{ flex: 'auto', flexDirection: dimension, alignItems: 'center', justifyContent: 'center', width: '100%' }}>
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-          {/* Ask the user whether they want to move to above plate position */}
+      <>
+        <View
+          style={{
+            flex: 1,
+            flexDirection: 'row',
+            justifyContent: 'center',
+            alignItems: 'center',
+            width: '100%'
+          }}
+        >
           <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
-            Move above plate
-          </p>
-          {/* Icon to move above plate */}
-          <Button
-            variant='success'
-            className='mx-2 mb-2 btn-huge'
-            size='lg'
-            onClick={moveAbovePlate}
-            style={{ width: buttonWidth, height: buttonHeight }}
-          >
-            <img
-              src={moveAbovePlateImage}
-              alt='move_above_plate_image'
-              className='center'
-              style={{ width: iconWidth, height: iconHeight }}
+            <input
+              name='biteDoneAutoContinue'
+              type='checkbox'
+              checked={biteDoneAutoContinue}
+              onChange={(e) => {
+                clearTimer()
+                setBiteDoneAutoContinue(e.target.checked)
+              }}
+              style={{ transform: 'scale(2.0)', verticalAlign: 'middle', marginRight: '15px' }}
             />
-          </Button>
-        </View>
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-          {/* Ask the user whether they want to move to resting position */}
-          <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
-            Rest to the side
+            Auto-continu{remainingSeconds === null ? 'e' : 'ing in ' + remainingSeconds + ' seconds'}
           </p>
-          {/* Icon to move to resting position */}
-          <Button
-            variant='warning'
-            className='mx-2 mb-2 btn-huge'
-            size='lg'
-            onClick={moveToRestingPosition}
-            style={{ width: buttonWidth, height: buttonHeight }}
-          >
-            <img
-              src={moveToRestingPositionImage}
-              alt='move_to_resting_image'
-              className='center'
-              style={{ width: iconWidth, height: iconHeight }}
-            />
-          </Button>
         </View>
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-          {/* Ask the user whether they want to move to resting position */}
-          <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
-            Move away from mouth
-          </p>
-          {/* Icon to move to resting position */}
-          <Button
-            variant='warning'
-            className='mx-2 mb-2 btn-huge'
-            size='lg'
-            onClick={moveToStagingConfiguration}
-            style={{ width: buttonWidth, height: buttonHeight }}
-          >
-            <img
-              src={moveToStagingConfigurationImage}
-              alt='move_to_staging_image'
-              className='center'
-              style={{ width: iconWidth, height: iconHeight }}
-            />
-          </Button>
+        <View style={{ flex: 9, flexDirection: dimension, alignItems: 'center', justifyContent: 'center', width: '100%' }}>
+          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+            {/* Ask the user whether they want to move to above plate position */}
+            <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+              Move above plate
+            </p>
+            {/* Icon to move above plate */}
+            <Button
+              variant='success'
+              className='mx-2 mb-2 btn-huge'
+              size='lg'
+              onClick={moveAbovePlate}
+              style={{ width: buttonWidth, height: buttonHeight }}
+            >
+              <img
+                src={moveAbovePlateImage}
+                alt='move_above_plate_image'
+                className='center'
+                style={{ width: iconWidth, height: iconHeight }}
+              />
+            </Button>
+          </View>
+          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+            {/* Ask the user whether they want to move to resting position */}
+            <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+              Rest to the side
+            </p>
+            {/* Icon to move to resting position */}
+            <Button
+              variant='warning'
+              className='mx-2 mb-2 btn-huge'
+              size='lg'
+              onClick={moveToRestingPosition}
+              style={{ width: buttonWidth, height: buttonHeight }}
+            >
+              <img
+                src={moveToRestingPositionImage}
+                alt='move_to_resting_image'
+                className='center'
+                style={{ width: iconWidth, height: iconHeight }}
+              />
+            </Button>
+          </View>
+          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+            {/* Ask the user whether they want to move to resting position */}
+            <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+              Move away from mouth
+            </p>
+            {/* Icon to move to resting position */}
+            <Button
+              variant='warning'
+              className='mx-2 mb-2 btn-huge'
+              size='lg'
+              onClick={moveToStagingConfiguration}
+              style={{ width: buttonWidth, height: buttonHeight }}
+            >
+              <img
+                src={moveToStagingConfigurationImage}
+                alt='move_to_staging_image'
+                className='center'
+                style={{ width: iconWidth, height: iconHeight }}
+              />
+            </Button>
+          </View>
         </View>
-      </View>
+      </>
     )
   }, [
+    biteDoneAutoContinue,
     buttonHeight,
     buttonWidth,
     dimension,
@@ -139,6 +295,9 @@ const BiteDone = () => {
     moveToRestingPositionImage,
     moveToStagingConfiguration,
     moveToStagingConfigurationImage,
+    remainingSeconds,
+    clearTimer,
+    setBiteDoneAutoContinue,
     textFontSize
   ])
 

--- a/feedingwebapp/src/Pages/Home/MealStates/BiteDone.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/BiteDone.jsx
@@ -229,7 +229,7 @@ const BiteDone = () => {
             {biteDoneAutoContinue
               ? remainingSeconds === null
                 ? 'Waiting for the fork to be empty'
-                : 'Moving away in ' + remainingSeconds + ' seconds'
+                : 'Moving away in ' + remainingSeconds + ' secs'
               : ''}
           </p>
         </View>


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

Joint with [`ada_feeding`#169](https://github.com/personalrobotics/ada_feeding/pull/169), this PR adds the web app capability to auto-continue once food has consistently been (not( detected on the fork for 3 seconds, both in BiteDone and BiteAcquisitionCheck, and auto-continue if so. The user has the option to decide whether to enable or disable this auto-continue. The 5 secs and probability threshold are currently hardcoded; customizing them from the settings menu will be another PR.

## Explain how this pull request was tested, including but not limited to the below checkmarks.

**Test with dummy nodes**:

- [x] Start code as per usual: `python3 src/ada_feeding/start.py --sim dummy`
- [x] Bite Done:
    - [x] Navigate to the Bite Done page. Verify that `Auto-Continue` is unchecked by default.
    - [x] Open up the console to see when FoF is predicting 1 (food on fork).
    - [x] While FoF is predicting 1, check the auto-continue box. Verify that the next time it predicts 0 (no FoF), a 5 second countdown starts. Once that countdown terminates, it should automatically move away and back above plate.
    - [x] Go back to BiteDone. During the countdown at >1s, uncheck the box. Verify that the countdown stops and app does not move on.
    - [x] While FoF is predicting 0, recheck the box. Verify that the countdown starts, but as soon as FoF switches to 1 (hopefully before the 5s countdown ends -- if not, wait longer before checking the box), the countdown stops and app does not move on.
    - [x] While FoF is predicting 1, check the box. During the countdown at <=1s, uncheck the box. Verify that the countdown stops and app does not move on.
- [x] Bite Acquisition Check:
    - [x] Navigate to the Bite Acquisition Check page. Verify that `Auto-Continue` is unchecked by default.
    - [x] Open up the console to see when FoF is predicting 1 (food on fork).
    - [x] While FoF is predicting 1, check the auto-continue box. Verify that it starts counting down and moves to the staging configuration.
    - [x] Go back to BiteAcquisitionCheck. During the countdown at >1s, uncheck the box. Verify that the countdown stops and app does not move on.
    - [x] While FoF is predicting 0, recheck the box. Verify that the countdown starts and it moves back above the plate.
    - [x] From BiteDone, go back to the resting configuration. From there, verify it *doesn't* auto-continue.
    - [x] Uncheck the box during a countdown for FoF and verify it stops the countdown and doesn't continue.
    - [x] Uncheck the box during a countdown for no FoF and verify it stops the countdown and doesn't continue.
- [x] Close code as per usual: `python3 src/ada_feeding/start.py --sim dummy -c`

**Test on the real robot**:

- [x] Start code as per usual: `python3 src/ada_feeding/start.py --sim dummy`
- [x] Bite Done:
    - [x] Navigate to BiteDone with real food on the fork. Verify that it doesn't move away.
    - [x] Adversarially move your head around behind the fork, verify that it doesn't move away.
    - [x] Eat the bite. While your mouth is on the fork, adversarially move it around. Verify it doesn't move away.
    - [x] Take your mouth off of the fork but leave the bite on. Verify that it doesn't move away.
    - [x] Eat the bite, but keep your mouth touching the fork tip. Verify that it does not move away.
    - [x] Move your mouth back. Verify that it does move away.
    - [x] Re-do a whole bite, eat the bite normally, verify that it works as expected.
    - [x] Adversarially try many different actions, verify that it feels safe.
- [x] Bite Acquisition Check:
    - [x] Navigate to BiteAcquisitionCheck with real food on the fork. Verify that it moves away.
    - [x] Navigate to BiteAcquisitionCheck with no FoF. Verify that it moves back above the plate.
    - [x] Navigate to BiteAcquisitionCheck with no FoF. During the countdown, touch the fork. Verify the countdown stops. Remove your finger before the new countdown ends. Verify that it doesn't auto-continue.
    - [x] During a countdown, uncheck the box. Verify it doesn't continue.
    - [x] Be adversarial. Verify it works.

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [x] Format Python code by running `python3 -m black .` in the top-level of this repository
- [x] Thoroughly test your code's functionality, including unintended uses.
- [x] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [x] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
