### PR TITLE
Allow users to set multiple parameter presets

### DIFF
--- a/feeding_web_app_ros2_test/feeding_web_app_ros2_test/FaceDetection.py
+++ b/feeding_web_app_ros2_test/feeding_web_app_ros2_test/FaceDetection.py
@@ -14,10 +14,10 @@ from threading import Lock
 class FaceDetectionNode(Node):
     def __init__(
         self,
-        face_detection_interval=90,
-        num_images_with_face=60,
-        open_mouth_interval=90,
-        num_images_with_open_mouth=30,
+        face_detection_interval=45,
+        num_images_with_face=30,
+        open_mouth_interval=45,
+        num_images_with_open_mouth=15,
     ):
         """
         Initializes the FaceDetection node, which exposes a SetBool

--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -126,6 +126,9 @@ export const GET_PARAMETERS_SERVICE_TYPE = 'rcl_interfaces/srv/GetParameters'
 export const SET_PARAMETERS_SERVICE_NAME = 'ada_feeding_action_servers/set_parameters'
 export const SET_PARAMETERS_SERVICE_TYPE = 'rcl_interfaces/srv/SetParameters'
 
+// The names of parameters users can change in the settings menu
+export const DISTANCE_TO_MOUTH_PARAM = 'MoveToMouth.tree_kwargs.plan_distance_from_mouth'
+
 /**
  * The meaning of the status that motion actions return in their results.
  * These should match the action definition(s).

--- a/feedingwebapp/src/Pages/GlobalState.jsx
+++ b/feedingwebapp/src/Pages/GlobalState.jsx
@@ -75,6 +75,9 @@ export const SETTINGS_STATE = {
   BITE_TRANSFER: 'BITE_TRANSFER'
 }
 
+// The name of the default parameter namespace
+export const DEFAULT_NAMESPACE = 'default'
+
 /**
  * useGlobalState is a hook to store and manipulate web app state that we want
  * to persist across re-renders and refreshes. It won't persist if cookies are
@@ -93,6 +96,7 @@ export const useGlobalState = create(
       mealStateTransitionTime: Date.now(),
       // The currently displayed settings page
       settingsState: SETTINGS_STATE.MAIN,
+      settingsPresets: { current: DEFAULT_NAMESPACE, customNames: [] },
       // The goal for the bite acquisition action, including the most recent
       // food item that the user selected in "bite selection"
       biteAcquisitionActionGoal: null,
@@ -155,6 +159,10 @@ export const useGlobalState = create(
       setSettingsState: (settingsState) =>
         set(() => ({
           settingsState: settingsState
+        })),
+      setSettingsPresets: (settingsPresets) =>
+        set(() => ({
+          settingsPresets: settingsPresets
         })),
       setBiteAcquisitionActionGoal: (biteAcquisitionActionGoal) =>
         set(() => ({

--- a/feedingwebapp/src/Pages/Settings/BiteTransfer.jsx
+++ b/feedingwebapp/src/Pages/Settings/BiteTransfer.jsx
@@ -285,7 +285,8 @@ const BiteTransfer = (props) => {
               flexDirection: 'column',
               justifyContent: 'center',
               alignItems: 'center',
-              width: '100%'
+              width: '100%',
+              zIndex: 1
             }}
           >
             <Label

--- a/feedingwebapp/src/Pages/Settings/Main.jsx
+++ b/feedingwebapp/src/Pages/Settings/Main.jsx
@@ -1,111 +1,278 @@
 // React imports
-import React from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import Button from 'react-bootstrap/Button'
+import ButtonGroup from 'react-bootstrap/ButtonGroup'
+import Dropdown from 'react-bootstrap/Dropdown'
+import DropdownButton from 'react-bootstrap/DropdownButton'
+import Modal from 'react-bootstrap/Modal'
 import Container from 'react-bootstrap/Container'
 import Row from 'react-bootstrap/Row'
+import Col from 'react-bootstrap/Col'
 import Image from 'react-bootstrap/Image'
+import { toast } from 'react-toastify'
 
 // Local imports
-import { MOVING_STATE_ICON_DICT } from '../Constants'
-import { useGlobalState, /* SETTINGS, */ MEAL_STATE, SETTINGS_STATE } from '../GlobalState'
-// import ToggleButtonGroup from '../../buttons/ToggleButtonGroup'
+import { useGlobalState, DEFAULT_NAMESPACE, MEAL_STATE, SETTINGS_STATE } from '../GlobalState'
+import { useROS, createROSService, createROSServiceRequest, getParameterValue } from '../../ros/ros_helpers'
+import {
+  GET_PARAMETERS_SERVICE_NAME,
+  GET_PARAMETERS_SERVICE_TYPE,
+  MOVING_STATE_ICON_DICT,
+  SET_PARAMETERS_SERVICE_NAME,
+  SET_PARAMETERS_SERVICE_TYPE
+} from '../Constants'
 
 /**
  * The Main component displays all the settings users are able to configure.
  */
 const Main = () => {
+  // Create a local state variable to store whether the new preset modal is showing
+  const [showNewPresetModal, setShowNewPresetModal] = useState(false)
+
   // Get relevant global state variables
   const setSettingsState = useGlobalState((state) => state.setSettingsState)
+  const settingsPresets = useGlobalState((state) => state.settingsPresets)
+  const setSettingsPresets = useGlobalState((state) => state.setSettingsPresets)
+
+  // A reference for the new preset preset
+  const newPresetInput = useRef(null)
+
+  /**
+   * Connect to ROS, if not already connected. Put this in useRef to avoid
+   * re-connecting upon re-renders.
+   */
+  const ros = useRef(useROS().ros)
+
+  /**
+   * Create the ROS Service Clients to get/set parameters.
+   */
+  let getParametersService = useRef(createROSService(ros.current, GET_PARAMETERS_SERVICE_NAME, GET_PARAMETERS_SERVICE_TYPE))
+  let setParametersService = useRef(createROSService(ros.current, SET_PARAMETERS_SERVICE_NAME, SET_PARAMETERS_SERVICE_TYPE))
+
+  // Get the custom preset names from the robot
+  const updatePresetsFromRobot = useCallback(() => {
+    let service = getParametersService.current
+    let request = createROSServiceRequest({
+      names: ['custom_namespaces', 'namespace_to_use']
+    })
+    service.callService(request, (response) => {
+      console.log('Got `custom_namespaces` response', response)
+      if (response.values.length > 1 && response.values[0].type === 9 && response.values[1].type === 4) {
+        setSettingsPresets({
+          current: getParameterValue(response.values[1]),
+          customNames: getParameterValue(response.values[0])
+        })
+      } else {
+        setSettingsPresets({
+          current: DEFAULT_NAMESPACE,
+          customNames: []
+        })
+      }
+    })
+  }, [setSettingsPresets])
+
+  // The first time this component is mounted, get the preset names
+  useEffect(() => {
+    updatePresetsFromRobot()
+  }, [updatePresetsFromRobot])
+
+  // Callback for when the user changes the preset
+  const setPreset = useCallback(
+    (preset, create_if_not_exist = true) => {
+      console.log('setPreset', preset, create_if_not_exist)
+      let presetOptions
+      if (create_if_not_exist && preset !== DEFAULT_NAMESPACE && !settingsPresets.customNames.includes(preset)) {
+        presetOptions = settingsPresets.customNames.concat([preset])
+      } else {
+        presetOptions = settingsPresets.customNames
+      }
+
+      let service = setParametersService.current
+      let request = createROSServiceRequest({
+        parameters: [
+          {
+            name: 'namespace_to_use',
+            value: {
+              type: 4, // string
+              string_value: preset
+            }
+          },
+          {
+            name: 'custom_namespaces',
+            value: {
+              type: 9, // string array
+              string_array_value: presetOptions
+            }
+          }
+        ]
+      })
+      console.log('Calling service', request)
+      service.callService(request, (response) => {
+        console.log('Got response', response)
+        if (response != null && response.results.length > 1 && response.results[0].successful && response.results[1].successful) {
+          setSettingsPresets({
+            current: preset,
+            customNames: presetOptions
+          })
+        }
+      })
+    },
+    [setParametersService, settingsPresets, setSettingsPresets]
+  )
+
+  // Callback for when the user navigates to a settings page
+  const onClickSettingsPage = useCallback(
+    (settingsState) => {
+      if (settingsPresets.current === DEFAULT_NAMESPACE) {
+        toast('To change settings, select a preset other than `' + DEFAULT_NAMESPACE + '`.', { type: 'error' })
+      } else {
+        setSettingsState(settingsState)
+      }
+    },
+    [setSettingsState, settingsPresets]
+  )
 
   // Get icon image for move to mouth
   let moveToMouthConfigurationImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingToMouth]
 
   return (
-    <Container fluid>
-      {/**
-       * The title of the page.
-       */}
-      <Row className='justify-content-center mx-1 my-2'>
-        <h1 style={{ textAlign: 'center', fontSize: '40px' }} className='txt-huge'>
-          ⚙ Settings
-        </h1>
-      </Row>
+    <>
+      <Container fluid>
+        {/**
+         * The title of the page.
+         */}
+        <Row className='justify-content-center mx-1 my-2'>
+          <h1 style={{ textAlign: 'center', fontSize: '40px' }} className='txt-huge'>
+            ⚙ Settings
+          </h1>
+        </Row>
 
-      <Row className='justify-content-center mx-1 my-2'>
-        <Button
-          variant='outline-dark'
-          style={{
-            fontSize: '30px',
-            display: 'flex',
-            flexDirection: 'row',
-            justifyContent: 'center',
-            alignItems: 'center',
-            height: '8vh',
-            borderWidth: '3px'
-          }}
-          onClick={() => setSettingsState(SETTINGS_STATE.BITE_TRANSFER)}
-        >
-          <Image
-            fluid
-            src={moveToMouthConfigurationImage}
+        {/**
+         * The preset settings element.
+         */}
+        <Row className='justify-content-center mx-1 my-2'>
+          <Col>
+            <p style={{ fontSize: '25px', textAlign: 'right', margin: '0rem' }}>Preset:</p>
+          </Col>
+          <Col>
+            <DropdownButton
+              as={ButtonGroup}
+              key='settingsPresets'
+              id={`dropdown-button-drop-down`}
+              drop='down'
+              variant='secondary'
+              title={settingsPresets.current}
+              size='lg'
+            >
+              <Dropdown.Item
+                key={DEFAULT_NAMESPACE}
+                onClick={() => setPreset(DEFAULT_NAMESPACE)}
+                active={DEFAULT_NAMESPACE === settingsPresets.current}
+              >
+                {DEFAULT_NAMESPACE}
+              </Dropdown.Item>
+              <Dropdown.Divider />
+              {settingsPresets.customNames.map((preset) => (
+                <Dropdown.Item key={preset} onClick={() => setPreset(preset)} active={preset === settingsPresets.current}>
+                  {preset}
+                </Dropdown.Item>
+              ))}
+              <Dropdown.Divider />
+              <Dropdown.Item onClick={() => setShowNewPresetModal(true)}>+ New Preset</Dropdown.Item>
+            </DropdownButton>
+          </Col>
+        </Row>
+
+        {/**
+         * The button to navigate to the bite transfer settings page.
+         */}
+        <Row className='justify-content-center mx-1 my-2'>
+          <Button
+            variant='outline-dark'
             style={{
-              height: '100%',
-              '--bs-btn-padding-x': '0rem',
-              '--bs-btn-padding-y': '0rem',
-              display: 'flex'
-            }}
-            alt='move_to_mouth_image'
-            className='center'
-          />
-          <p
-            style={{
+              fontSize: '30px',
               display: 'flex',
-              marginTop: '1rem'
+              flexDirection: 'row',
+              justifyContent: 'center',
+              alignItems: 'center',
+              height: '8vh',
+              borderWidth: '3px'
+            }}
+            onClick={() => onClickSettingsPage(SETTINGS_STATE.BITE_TRANSFER)}
+          >
+            <Image
+              fluid
+              src={moveToMouthConfigurationImage}
+              style={{
+                height: '100%',
+                '--bs-btn-padding-x': '0rem',
+                '--bs-btn-padding-y': '0rem',
+                display: 'flex'
+              }}
+              alt='move_to_mouth_image'
+              className='center'
+            />
+            <p
+              style={{
+                display: 'flex',
+                marginTop: '1rem'
+              }}
+            >
+              Bite Transfer
+            </p>
+          </Button>
+        </Row>
+      </Container>
+
+      {/**
+       * A modal to allow users to specify the name of their new preset.
+       */}
+      <Modal
+        show={showNewPresetModal}
+        onHide={() => setShowNewPresetModal(false)}
+        size='lg'
+        aria-labelledby='contained-modal-title-vcenter'
+        backdrop='static'
+        keyboard={false}
+        centered
+        id='newPresetModal'
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id='contained-modal-title-vcenter' style={{ fontSize: '30px' }}>
+            Add New Preset
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body style={{ textAlign: 'center' }}>
+          <input
+            ref={newPresetInput}
+            type='text'
+            id='newPresetName'
+            name='newPresetName'
+            placeholder='Enter new preset name'
+            style={{ fontSize: '25px', verticalAlign: 'middle' }}
+          />
+          <br />
+          <Button
+            variant='secondary'
+            style={{ fontSize: '25px', marginTop: '1rem' }}
+            onClick={() => {
+              // Get the new preset name
+              let newPresetName = newPresetInput.current.value.trim()
+
+              if (newPresetName.length === 0) {
+                toast('Please enter a name for the new preset.', { type: 'error' })
+                return
+              } else {
+                setPreset(newPresetName)
+                setShowNewPresetModal(false)
+              }
             }}
           >
-            Bite Transfer
-          </p>
-        </Button>
-      </Row>
-
-      {/**
-       * Load toggle-able buttons for all the settings.
-       *
-       * TODO:
-       *   - Instead of having a full sentence "title" for every setting, we
-       *     should have a brief title with an optional "i" on the right side
-       *     that users can click for additional information to pop up (perhaps
-       *     as a Modal?)
-       *   - We shouldn't assume all settings will be ToggleButtonGroup.
-       *     For example, bite initiation settings should instead be checkboxes.
-       */}
-      {/* <Row className='justify-content-center mx-1 my-2'>
-        <Form.Label style={{ fontSize: '30px' }}>Where should the robot wait after it gets food? </Form.Label>
-        <ToggleButtonGroup
-          valueOptions={SETTINGS.stagingPosition}
-          currentValue={useGlobalState((state) => state.stagingPosition)}
-          valueSetter={useGlobalState((state) => state.setStagingPosition)}
-        />
-      </Row>
-
-      <Row className='justify-content-center mx-1 my-2'>
-        <Form.Label style={{ fontSize: '30px' }}>How do you want to indicate readiness for a bite? </Form.Label>
-        <ToggleButtonGroup
-          valueOptions={SETTINGS.biteInitiation}
-          currentValue={useGlobalState((state) => state.biteInitiation)}
-          valueSetter={useGlobalState((state) => state.setBiteInitiation)}
-        />
-      </Row>
-
-      <Row className='justify-content-center mx-1 my-2'>
-        <Form.Label style={{ fontSize: '30px' }}>How do you want to select your desired food item? </Form.Label>
-        <ToggleButtonGroup
-          valueOptions={SETTINGS.biteSelection}
-          currentValue={useGlobalState((state) => state.biteSelection)}
-          valueSetter={useGlobalState((state) => state.setBiteSelection)}
-        />
-      </Row> */}
-    </Container>
+            Create
+          </Button>
+        </Modal.Body>
+      </Modal>
+    </>
   )
 }
 

--- a/feedingwebapp/src/Pages/Settings/Main.jsx
+++ b/feedingwebapp/src/Pages/Settings/Main.jsx
@@ -120,6 +120,20 @@ const Main = () => {
     [setParametersService, settingsPresets, setSettingsPresets]
   )
 
+  // Callback for when users enter the new preset name
+  const enterNewPresetName = useCallback(() => {
+    // Get the new preset name
+    let newPresetName = newPresetInput.current.value.trim()
+
+    if (newPresetName.length === 0) {
+      toast('Please enter a name for the new preset.', { type: 'error' })
+      return
+    } else {
+      setPreset(newPresetName)
+      setShowNewPresetModal(false)
+    }
+  }, [newPresetInput, setPreset])
+
   // Callback for when the user navigates to a settings page
   const onClickSettingsPage = useCallback(
     (settingsState) => {
@@ -230,6 +244,11 @@ const Main = () => {
       <Modal
         show={showNewPresetModal}
         onHide={() => setShowNewPresetModal(false)}
+        onShow={() => {
+          if (newPresetInput.current !== null) {
+            newPresetInput.current.focus()
+          }
+        }}
         size='lg'
         aria-labelledby='contained-modal-title-vcenter'
         backdrop='static'
@@ -250,24 +269,14 @@ const Main = () => {
             name='newPresetName'
             placeholder='Enter new preset name'
             style={{ fontSize: '25px', verticalAlign: 'middle' }}
-          />
-          <br />
-          <Button
-            variant='secondary'
-            style={{ fontSize: '25px', marginTop: '1rem' }}
-            onClick={() => {
-              // Get the new preset name
-              let newPresetName = newPresetInput.current.value.trim()
-
-              if (newPresetName.length === 0) {
-                toast('Please enter a name for the new preset.', { type: 'error' })
-                return
-              } else {
-                setPreset(newPresetName)
-                setShowNewPresetModal(false)
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                enterNewPresetName()
               }
             }}
-          >
+          />
+          <br />
+          <Button variant='secondary' style={{ fontSize: '25px', marginTop: '1rem' }} onClick={enterNewPresetName}>
             Create
           </Button>
         </Modal.Body>


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

This PR, paired with [`ada_feeding`#172](https://github.com/personalrobotics/ada_feeding/pull/172), allows users to maintain multiple parameter configurations and switch between them.
- On the main settings page, the user can choose which preset they want to use. If they want to change any parameters, they must be on a non-default preset.
- On any page that allows changing settings (e.g., the BiteTransfer page), the user can change settings for that preset, and can revert settings for that preset to any of the other presets.

## Explain how this pull request was tested, including but not limited to the below checkmarks.

Pull this code and [`ada_feeding`#172](https://github.com/personalrobotics/ada_feeding/pull/172) code and rebuild.

- [x] Launch the code in mock: `python3 src/ada_feeding/start.py --sim mock`
- [x] In the web app, go to “Settings.” Verify that “default” is the current preset.
- [x] In the web app, click “Bite Transfer.” Verify it doesn’t let you do so on the “default” preset.
- [x] In the web app, create a new preset called “test1”. Verify that *in the share directory* (within the `install` folder of the workspace), `ada_feeding_action_servers_custom.yaml`  shows “test1” under `namespace_to_use` and `custom_namespaces`.
- [x] In the web app, create a new preset called “test2.” Verify all of the above.
- [x] In the web app, switch to preset “default.” Verify it is reflected in the YAML file.
- [x] In the web app, click “Bite Transfer.” Verify it doesn’t let you do so.
- [x] In the web app, create a new preset called “test3.” Verify all of the above.
- [x] In the web app, click “Bite Transfer.” Verify it does let you do so, and it shows “test3” as the preset you’re currently changing.
- [x] In the web app, change “distance to mouth” to 5cm. Verify it is reflected in the YAML.
- [x] In the web app, go back to the main “Settings” page, change the preset to “test2,” then go into “Bite Transfer.” Verify the distance starts at 2.5cm, and then change the distance to 1cm. Verify it is reflected in the YAML.
- [x] In the web app, revert the distance back to each of the presets. For test1 it should go to 2.5, for test3 to 5, and for default to 2.5. Verify each of those are updated in the YAML.
- [x] In the web app, set “test2” to 1cm.
- [x] Add another preset `test4`, on the "Bite Transfer" settings page verify that the "set to..." dropdown menu is properly rendered.
- [x] Set "test2" to the current preset
- [x] Terminate the `ada_feeding` code, re-launch it, and verify all settings are still saved.
- [x] In the web app, leave the Settings menu. Go through until the robot is at the user’s mouth. Verify in RVIZ it is 1cm away.
- [x] In the web app, on the BiteDone page (with auto-continue unchecked), go into Settings and change it to “test3.” Then go back to staging and back to MoveToMouth, verify it goes 5cm away.
- [x] In the web app, do the same as above but setting it to “default,” verify it goes 2.5cm away.

 
***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [x] Format Python code by running `python3 -m black .` in the top-level of this repository
- [x] Thoroughly test your code's functionality, including unintended uses.
- [x] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [x] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
