### PR TITLE
Switch to Compressed Depth Images

### DIFF
--- a/feeding_web_app_ros2_test/launch/feeding_web_app_dummy_nodes_launch.xml
+++ b/feeding_web_app_ros2_test/launch/feeding_web_app_dummy_nodes_launch.xml
@@ -22,7 +22,7 @@
     <node pkg="feeding_web_app_ros2_test" exec="DummyRealSense" name="DummyRealSense">
       <remap from="~/image" to="/camera/color/image_raw"/>
       <remap from="~/compressed_image" to="/camera/color/image_raw/compressed"/>
-      <remap from="~/aligned_depth" to="/camera/aligned_depth_to_color/image_raw"/>
+      <remap from="~/aligned_depth" to="/camera/aligned_depth_to_color/image_raw/compressedDepth"/>
       <remap from="~/camera_info" to="/camera/color/camera_info"/>
       <remap from="~/aligned_depth/camera_info" to="/camera/aligned_depth_to_color/camera_info"/>
       <param name="fps" value="15"/>

--- a/feedingwebapp/src/Pages/Home/MealStates/BiteAcquisitionCheck.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/BiteAcquisitionCheck.jsx
@@ -137,16 +137,16 @@ const BiteAcquisitionCheck = () => {
     (message) => {
       console.log('Got food-on-fork detection message', message)
       // Only auto-continue if the previous state was Bite Acquisition
-      if (biteAcquisitionCheckAutoContinue && prevMealState === MEAL_STATE.R_BiteAcquisition && message.status === 1) {
+      if (biteAcquisitionCheckAutoContinue && prevMealState === MEAL_STATE.R_BiteAcquisition) {
         let callbackFn = null
-        if (message.probability < biteAcquisitionCheckAutoContinueProbThreshLower) {
+        if (message.status === -1 || (message.status === 1 && message.probability < biteAcquisitionCheckAutoContinueProbThreshLower)) {
           console.log('No FoF. Auto-continuing in ', remainingSeconds, ' seconds')
           if (timerWasForFof.current === true) {
             clearTimer()
           }
           timerWasForFof.current = false
           callbackFn = acquisitionFailure
-        } else if (message.probability > biteAcquisitionCheckAutoContinueProbThreshUpper) {
+        } else if (message.status === 1 && message.probability > biteAcquisitionCheckAutoContinueProbThreshUpper) {
           console.log('FoF. Auto-continuing in ', remainingSeconds, ' seconds')
           if (timerWasForFof.current === false) {
             clearTimer()
@@ -154,7 +154,7 @@ const BiteAcquisitionCheck = () => {
           timerWasForFof.current = true
           callbackFn = acquisitionSuccess
         } else {
-          console.log('Not auto-continuing due to probability between thresholds')
+          console.log('Not auto-continuing due to probability between thresholds or errors')
           clearTimer()
         }
         // Don't override an existing timer


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

This PR, joint with [ada_feeding#174](https://github.com/personalrobotics/ada_feeding/pull/174), extends the dummy RealSense code to also publish the compressed depth image.

This PR also makes a small change to how food-on-fork is handled after bite acquisition; if too few points are detected (status -1, as defined in [the message](https://github.com/personalrobotics/ada_feeding/blob/c6f9674fee737067fdbbcd594774098202078338/ada_feeding_msgs/msg/FoodOnForkDetection.msg#L9)), assume there is no FoF.

## Explain how this pull request was tested, including but not limited to the below checkmarks.

- [x] Temporarily comment out [the two lines](https://github.com/personalrobotics/ada_ros2/blob/4766db42f02f9c09c88e7a92a80a9cfe1bf53572/ada_moveit/launch/move_group.launch.py#L26) in the `move_group` launchfile that remove the Octomap when running in sim mock.
- [x] Launch the code in sim: `python3 src/ada_feeding/start.py --sim mock`
- [x] Launch RVIZ, verify the Octomap shows up and has the expected shape.

- [x] In real, do an acquisition and have the robot move to the resting pose. Shine a light on the fork or do something else to ensure too few points are detected (this can be verified by echoing the topic). Ensure that the app behaves as if there is no food on the fork.

***

**Before creating a pull request**

- [N/A] Format React code with `npm run format`
- [x] Format Python code by running `python3 -m black .` in the top-level of this repository
- [N/A] Thoroughly test your code's functionality, including unintended uses.
- [N/A] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [N/A] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
