### PR TITLE
Allow users to customize the resting configuration

### DIFF
--- a/feedingwebapp/src/Pages/GlobalState.jsx
+++ b/feedingwebapp/src/Pages/GlobalState.jsx
@@ -82,7 +82,8 @@ export { NON_MOVING_STATES }
 export const SETTINGS_STATE = {
   MAIN: 'MAIN',
   BITE_TRANSFER: 'BITE_TRANSFER',
-  ABOVE_PLATE: 'ABOVE_PLATE'
+  ABOVE_PLATE: 'ABOVE_PLATE',
+  RESTING_CONFIGURATION: 'RESTING_CONFIGURATION'
 }
 
 // The name of the default parameter namespace

--- a/feedingwebapp/src/Pages/Header/TeleopSubcomponent.jsx
+++ b/feedingwebapp/src/Pages/Header/TeleopSubcomponent.jsx
@@ -152,14 +152,14 @@ const TeleopSubcomponent = (props) => {
    * When the component is unmounted, stop servo.
    */
   useEffect(() => {
-    let stopServoSuccessCallback = props.stopServoSuccessCallback
+    let unmountCallback = props.unmountCallback
     return () => {
       console.log('Unmounting teleop subcomponent.')
       destroyActionClient(startCartesianControllerAction)
       destroyActionClient(startJointControllerAction)
-      stopServoSuccessCallback.current()
+      unmountCallback.current()
     }
-  }, [startCartesianControllerAction, startJointControllerAction, props.stopServoSuccessCallback])
+  }, [startCartesianControllerAction, startJointControllerAction, props.unmountCallback])
 
   /**
    * Callback function to publish constant cartesian cartesian velocity commands.
@@ -650,12 +650,12 @@ const TeleopSubcomponent = (props) => {
 }
 TeleopSubcomponent.propTypes = {
   // A reference to a function to be called if StopServo is succesfully run.
-  stopServoSuccessCallback: PropTypes.object,
+  unmountCallback: PropTypes.object,
   // A function to be called when one of the teleop buttons are released
   teleopButtonOnReleaseCallback: PropTypes.func
 }
 TeleopSubcomponent.defaultProps = {
-  stopServoSuccessCallback: { current: () => {} },
+  unmountCallback: { current: () => {} },
   teleopButtonOnReleaseCallback: () => {}
 }
 export default TeleopSubcomponent

--- a/feedingwebapp/src/Pages/Settings/Main.jsx
+++ b/feedingwebapp/src/Pages/Settings/Main.jsx
@@ -156,6 +156,7 @@ const Main = () => {
   // Get icon image for move to mouth
   let moveToMouthConfigurationImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingToMouth]
   let moveAbovePlateConfigurationImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingAbovePlate]
+  let moveToRestingConfigurationImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingToRestingPosition]
 
   // Configure the different options in the settings menu
   let settingsConfig = [
@@ -168,6 +169,11 @@ const Main = () => {
       title: 'Above Plate',
       icon: moveAbovePlateConfigurationImage,
       onClick: () => onClickSettingsPage(SETTINGS_STATE.ABOVE_PLATE)
+    },
+    {
+      title: 'Resting Position',
+      icon: moveToRestingConfigurationImage,
+      onClick: () => onClickSettingsPage(SETTINGS_STATE.RESTING_CONFIGURATION)
     }
   ]
 

--- a/feedingwebapp/src/Pages/Settings/Settings.jsx
+++ b/feedingwebapp/src/Pages/Settings/Settings.jsx
@@ -8,7 +8,7 @@ import { useGlobalState, SETTINGS_STATE, MEAL_STATE } from '../GlobalState'
 import Main from './Main'
 import CustomizeConfiguration from './CustomizeConfiguration'
 import BiteTransfer from './BiteTransfer'
-import { ABOVE_PLATE_PARAM_JOINTS } from '../Constants'
+import { ABOVE_PLATE_PARAM_JOINTS, RESTING_PARAM_JOINTS_1, RESTING_PARAM_JOINTS_2 } from '../Constants'
 
 /**
  * The Settings components displays the appropriate settings page based on the
@@ -40,6 +40,26 @@ const Settings = (props) => {
               {
                 name: 'Move to Resting',
                 mealState: MEAL_STATE.R_MovingToRestingPosition
+              }
+            ]}
+            webrtcURL={props.webrtcURL}
+          />
+        )
+      case SETTINGS_STATE.RESTING_CONFIGURATION:
+        return (
+          <CustomizeConfiguration
+            startingMealState={MEAL_STATE.R_MovingToRestingPosition}
+            paramNames={[RESTING_PARAM_JOINTS_1, RESTING_PARAM_JOINTS_2]}
+            configurationName='Resting Position'
+            buttonName='Move to Resting'
+            otherButtonConfigs={[
+              {
+                name: 'Move to Staging',
+                mealState: MEAL_STATE.R_MovingToStagingConfiguration
+              },
+              {
+                name: 'Move Above Plate',
+                mealState: MEAL_STATE.R_MovingAbovePlate
               }
             ]}
             webrtcURL={props.webrtcURL}

--- a/feedingwebapp/src/Pages/Settings/Settings.jsx
+++ b/feedingwebapp/src/Pages/Settings/Settings.jsx
@@ -4,10 +4,11 @@ import PropTypes from 'prop-types'
 import { View } from 'react-native'
 
 // Local imports
-import { useGlobalState, SETTINGS_STATE } from '../GlobalState'
+import { useGlobalState, SETTINGS_STATE, MEAL_STATE } from '../GlobalState'
 import Main from './Main'
-import AbovePlate from './AbovePlate'
+import CustomizeConfiguration from './CustomizeConfiguration'
 import BiteTransfer from './BiteTransfer'
+import { ABOVE_PLATE_PARAM_JOINTS } from '../Constants'
 
 /**
  * The Settings components displays the appropriate settings page based on the
@@ -25,7 +26,25 @@ const Settings = (props) => {
       case SETTINGS_STATE.BITE_TRANSFER:
         return <BiteTransfer webrtcURL={props.webrtcURL} />
       case SETTINGS_STATE.ABOVE_PLATE:
-        return <AbovePlate webrtcURL={props.webrtcURL} />
+        return (
+          <CustomizeConfiguration
+            startingMealState={MEAL_STATE.R_MovingAbovePlate}
+            paramNames={[ABOVE_PLATE_PARAM_JOINTS]}
+            configurationName='Above Plate'
+            buttonName='Move Above Plate'
+            otherButtonConfigs={[
+              {
+                name: 'Move to Staging',
+                mealState: MEAL_STATE.R_MovingToStagingConfiguration
+              },
+              {
+                name: 'Move to Resting',
+                mealState: MEAL_STATE.R_MovingToRestingPosition
+              }
+            ]}
+            webrtcURL={props.webrtcURL}
+          />
+        )
       default:
         console.log('Invalid settings state', settingsState)
         return <Main />


### PR DESCRIPTION
## Description

Building off of #133 , this PR allows users to customize the resting configuration. This essentially involves a small generalization of the AbovePlate component.

## Testing

- [x] Launch the code in real: `python3 src/ada_feeding/start.py`
- [x] Verify `Resting Position` Settings work:
    - [x] Regardless of what page you go to the Resting Position settings from, verify it moves above the plate when you load it and moves back when you click "Done"
        - [x] Bite Selection
        - [x] Bite Acquisition Check
        - [x] Detecting Face
        - [x] Bite Done
    - [x] Teleop it, verify the parameters in the YAML file only update when you stop holding the button, and that both parameters are saved.
    - [x] Click MoveToStaging. Verify it succeeds, and after that the teleop part is disabled.
    - [x] Click MovetoResting, and verify the teleop part gets re-enabled. Verify it moves to the customized above plate configuration.
    - [x] Repeat the above two with MoveAbovePlate.
    - [x] Reset to default, verify that it updates the param file and immediately moves above the plate to the default configuration.

## Future Work

User-driven customization poses a problem for the collision scene. For example, in this case, if they customize the elbow of the robot to be below the `in_front_of_wheelchair_wall`, then plans from the resting configuration will likely not succeed. With any customization, if the user moves the arm in collision with the workspace wall, all plans will fail. We need to think further about how to modify the collision scene as a function of these customizations, either automatically or allowing users to do it.

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [N/A] Format Python code by running `python3 -m black .` in the top-level of this repository
- [x] Thoroughly test your code's functionality, including unintended uses.
- [x] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [x] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
