### PR TITLE
Reset Workspace Walls When Customizing Configurations

### DIFF
--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -91,6 +91,8 @@ export const START_CARTESIAN_CONTROLLER_ACTION_NAME = 'ActivateCartesianControll
 export const START_CARTESIAN_CONTROLLER_ACTION_TYPE = 'ada_feeding_msgs/action/Trigger'
 export const START_JOINT_CONTROLLER_ACTION_NAME = 'ActivateJointController'
 export const START_JOINT_CONTROLLER_ACTION_TYPE = 'ada_feeding_msgs/action/Trigger'
+export const RECOMPUTE_WORKSPACE_WALLS_ACTION_NAME = 'recompute_workspace_walls'
+export const RECOMPUTE_WORKSPACE_WALLS_ACTION_TYPE = 'ada_feeding_msgs/action/Trigger'
 
 /**
  * For states that call ROS services, this dictionary contains

--- a/feedingwebapp/src/Pages/Settings/CustomizeConfiguration.jsx
+++ b/feedingwebapp/src/Pages/Settings/CustomizeConfiguration.jsx
@@ -446,6 +446,7 @@ const CustomizeConfiguration = (props) => {
       localParamValues={currentConfigurationParams}
       setLocalParamValues={setCurrentConfigurationParams}
       resetToPresetSuccessCallback={resetToPresetSuccessCallback}
+      resetWorkspaceWallsOnParameterUpdate={true}
     >
       {renderSettings()}
     </SettingsPageParent>

--- a/feedingwebapp/src/ros/ros_helpers.js
+++ b/feedingwebapp/src/ros/ros_helpers.js
@@ -115,6 +115,10 @@ export function createROSServiceRequest(data) {
   return new ROSLIB.ServiceRequest(data)
 }
 
+// TODO: Should we add a `destroyService` function like we have for the action client?
+// The difference is that roslibjs explicitly provides a function to destroy the action
+// client, but only provides a function to unadvertise a service client.
+
 /**
  * Create a ROS Action Client.
  *


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

As of [`ada_feeding`#181](https://github.com/personalrobotics/ada_feeding/pull/181), the robot code exposes an action to recompute workspace walls based on the currently-used robot arm configurations. This PR modifies the web app to call that action every time a configuration parameter is saved. This enables users to customize configurations without worrying about it leading the robot to be in collision with the workspace walls.

## Explain how this pull request was tested, including but not limited to the below checkmarks.

- [x] Launch the code in real: `python3 src/ada_feeding/start.py`
- [x] Expected Behavior Test:
    - [x] In the web app, start with the default preset, and then create a new preset.
    - [x] Customize the staging configuration to have the arm clearly collides with the right wall (e.g., rotate joint 1 to the right).
    - [x] Verify that the workspace walls update.
    - [x] Verify that the robot is able to move above the plate.
    - [x] Eat an entire bite with this configuration.
- [x] Stress Test 1:
    - [x] Go back to customizing the staging configuration. Hit multiple teleop buttons one after the other. Verify that the workspace walls update as expected, and there aren't issues from calling the action may times one-after-the-other.
- [x] Stress Test 2:
    - [x] Customize the above plate, resting, and staging configurations. Verify that a whole bite still works.
- [x] If all of the above works, try to use the web app interface to find a "staging + resting" pair that shortens the motion the arm takes to the staging configuration.
    - [x] (If the above is difficult, use it to motivate improvements to the UX.)

## Future Work

- The main issues with customizing all the configurations to get "short" robot arm motions was: (a) wrench thresholds exceeded, particularly if we did a full rotation of the arm; and (b) rosbridge / ros2 not reliably sending messages. Nothing dangerous happened as a result of this, but it sometimes slowed progress and it was unclear what to do.
- Currently, the customization page does quite a few things "silently" e.g., saving the parameters, activating the cartesian controller, recomputing workspace walls. Because the invokation of these services/actions are silent, their failures are also silent, which can led to unintuitive behaviors. Find a way to visually capture this silent information, for increased transparency.

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [ ] Format Python code by running `python3 -m black .` in the top-level of this repository
- [ ] Thoroughly test your code's functionality, including unintended uses.
- [ ] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [ ] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
