### PR TITLE
Allow `TeleopSubcomponent` to re-tare and change F/T threshold

### DIFF
--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -87,10 +87,10 @@ ROS_ACTIONS_NAMES[MEAL_STATE.R_StowingArm] = {
   messageType: 'ada_feeding_msgs/action/MoveTo'
 }
 export { ROS_ACTIONS_NAMES }
-export const START_CARTESIAN_CONTROLLER_ACTION_NAME = 'ActivateCartesianController'
-export const START_CARTESIAN_CONTROLLER_ACTION_TYPE = 'ada_feeding_msgs/action/Trigger'
-export const START_JOINT_CONTROLLER_ACTION_NAME = 'ActivateJointController'
-export const START_JOINT_CONTROLLER_ACTION_TYPE = 'ada_feeding_msgs/action/Trigger'
+export const ACTIVATE_CONTROLLER_ACTION_NAME = 'ActivateController'
+export const ACTIVATE_CONTROLLER_ACTION_TYPE = 'ada_feeding_msgs/action/ActivateController'
+export const CARTESIAN_CONTROLLER_NAME = 'jaco_arm_cartesian_controller'
+export const JOINT_CONTROLLER_NAME = 'jaco_arm_servo_controller'
 export const RECOMPUTE_WORKSPACE_WALLS_ACTION_NAME = 'recompute_workspace_walls'
 export const RECOMPUTE_WORKSPACE_WALLS_ACTION_TYPE = 'ada_feeding_msgs/action/Trigger'
 

--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -139,6 +139,11 @@ export const RESTING_PARAM_JOINTS_1 = 'AcquireFood.tree_kwargs.resting_joint_pos
 // TODO: We may need to remove the orientation constraint from the below action.
 export const RESTING_PARAM_JOINTS_2 = 'MoveToRestingPosition.tree_kwargs.goal_configuration'
 
+// Parameters for modifying the force threshold
+export const FORCE_THRESHOLD_PARAM = 'wrench_threshold.fMag'
+export const DEFAULT_FORCE_THRESHOLD = 1.0 // N
+export const INCREASED_FORCE_THRESHOLD = 75.0 // N
+
 // Robot link names
 export const ROBOT_BASE_LINK = 'j2n6s200_link_base'
 export const ROBOT_END_EFFECTOR = 'forkTip'

--- a/feedingwebapp/src/Pages/Header/InfoModal.jsx
+++ b/feedingwebapp/src/Pages/Header/InfoModal.jsx
@@ -94,7 +94,7 @@ function InfoModal(props) {
         <ToastContainer style={{ fontSize: textFontSize }} containerId={MODAL_CONTAINER_ID} enableMultiContainer={true} />
         <View
           style={{
-            flex: 2,
+            flex: 3,
             flexDirection: otherDirection,
             justifyContent: 'center',
             alignItems: 'center',
@@ -112,7 +112,7 @@ function InfoModal(props) {
         </View>
         <View
           style={{
-            flex: 9,
+            flex: 18,
             flexDirection: 'row',
             justifyContent: 'center',
             alignItems: 'center',
@@ -124,7 +124,7 @@ function InfoModal(props) {
           {mode === VIDEO_MODE ? (
             <VideoFeed topic={CAMERA_FEED_TOPIC} updateRateHz={10} webrtcURL={props.webrtcURL} />
           ) : mode === TELEOP_MODE ? (
-            <TeleopSubcomponent />
+            <TeleopSubcomponent allowIncreasingForceThreshold={true} />
           ) : mode === SYSTEM_STATUS_MODE ? (
             <div>System Status</div>
           ) : (

--- a/feedingwebapp/src/Pages/Header/TeleopSubcomponent.jsx
+++ b/feedingwebapp/src/Pages/Header/TeleopSubcomponent.jsx
@@ -623,7 +623,7 @@ const TeleopSubcomponent = (props) => {
         {/* Allow users to tune to speed of the current teleop mode */}
         <View
           style={{
-            flex: 1,
+            flex: props.allowIncreasingForceThreshold ? 1 : 2,
             flexDirection: 'row',
             justifyContent: 'center',
             alignItems: 'center',

--- a/feedingwebapp/src/ros/ros_helpers.js
+++ b/feedingwebapp/src/ros/ros_helpers.js
@@ -226,12 +226,12 @@ export function getParameterFromValue(value, typeOverride = null) {
   if (typeOverride === 1 || typeof value === 'boolean') {
     parameter.bool_value = value
     parameter.type = 1
-  } else if (typeOverride === 2 || Number.isInteger(value)) {
-    parameter.integer_value = value
-    parameter.type = 2
   } else if (typeOverride === 3 || typeof value === 'number') {
     parameter.double_value = value
     parameter.type = 3
+  } else if (typeOverride === 2 || Number.isInteger(value)) {
+    parameter.integer_value = value
+    parameter.type = 2
   } else if (typeOverride === 4 || typeof value === 'string') {
     parameter.string_value = value
     parameter.type = 4
@@ -241,12 +241,12 @@ export function getParameterFromValue(value, typeOverride = null) {
   } else if (typeOverride === 6 || (Array.isArray(value) && value.length > 0 && typeof value[0] === 'boolean')) {
     parameter.bool_array_value = value
     parameter.type = 6
-  } else if (typeOverride === 7 || (Array.isArray(value) && value.length > 0 && Number.isInteger(value[0]))) {
-    parameter.integer_array_value = value
-    parameter.type = 7
   } else if (typeOverride === 8 || (Array.isArray(value) && value.length > 0 && typeof value[0] === 'number')) {
     parameter.double_array_value = value
     parameter.type = 8
+  } else if (typeOverride === 7 || (Array.isArray(value) && value.length > 0 && Number.isInteger(value[0]))) {
+    parameter.integer_array_value = value
+    parameter.type = 7
   } else if (typeOverride === 9 || (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string')) {
     parameter.string_array_value = value
     parameter.type = 9


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

This PR, which builds upon [`ada_feeding`#183](https://github.com/personalrobotics/ada_feeding/pull/183), extends the `TeleopSubcomponent` as follows:
1. On mount and when the refresh button is clicked, has the teleop button re-tare the F/T sensor.
2. From the `InfoModal`, gives users the option to increase the F/T threshold (to 75N) and restore it (back to 1N).

## Explain how this pull request was tested, including but not limited to the below checkmarks.

- [x] Pull [`ada_feeding`#183](https://github.com/personalrobotics/ada_feeding/pull/183), re-build and source the workspace.
- [x] Launch the system in real: `python3 src/ada_feeding/start.py`
- [x] Load the teleop component, verify the F/T sensor re-tares and the correct controller is loaded:
    - [x] `InfoModal`
    - [x] `Settings > Above Plate`
- [x] Click refresh, verify the same as above.
    - [x] `InfoModal`
    - [x] `Settings > Above Plate`
- [x] In the `InfoModal`, increase the force threshold. Verify it actually increases. 
- [x] Unmount the teleop component. Verify the force threshold decreases. When you remount it, verify that the button that shows is to "increase" it, not "restore" it to the default.
- [x] Increase it, then click the decrease button, verify it actually decreases.
- [x] Increase it, then swap teleop modes. Verify it decreases.
- [x] Teleop the robot to experience a force, verify that pressing the refresh button allows you to move out of it briefly step-by-step.
- [x] Teleop the robot to experience a force, verify that  increasing the force threshold lets you move out of it all-at-onces.

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [N/A] Format Python code by running `python3 -m black .` in the top-level of this repository
- [x] Thoroughly test your code's functionality, including unintended uses.
- [x] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [x] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
