### PR TITLE
Allow users to customize the stow configuration

### DIFF
--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -138,6 +138,7 @@ export const STAGING_PARAM_ORIENTATION = 'MoveFromMouth.tree_kwargs.staging_conf
 export const RESTING_PARAM_JOINTS_1 = 'AcquireFood.tree_kwargs.resting_joint_positions'
 // TODO: We may need to remove the orientation constraint from the below action.
 export const RESTING_PARAM_JOINTS_2 = 'MoveToRestingPosition.tree_kwargs.goal_configuration'
+export const STOW_PARAM_JOINTS = 'MoveToStowLocation.tree_kwargs.joint_positions'
 
 // Parameters for modifying the force threshold
 export const FORCE_THRESHOLD_PARAM = 'wrench_threshold.fMag'

--- a/feedingwebapp/src/Pages/GlobalState.jsx
+++ b/feedingwebapp/src/Pages/GlobalState.jsx
@@ -76,15 +76,24 @@ export { NON_MOVING_STATES }
 /**
  * SETTINGS_STATE controls which settings page to display.
  *  - MAIN: The main page, with options to navigate to the other pages.
- *  - BITE_TRANSFER: The bite transfer page, where the user can configure
- *    parameters for bite transfer.
+ *  - DISTANCE_TO_MOUTH: Allow the user to customize how close the robot gets
+ *    to their mouth.
+ *  - ABOVE_PLATE: Allow the user to customize how high the fixed above plate
+ *    arm configuration.
+ *  - RESTING_CONFIGURATION: Allow the user to customize the fixed resting
+ *    arm configuration.
+ *  - STAGING_CONFIGURATION: Allow the user to customize the fixed staging
+ *    arm configuration.
+ *  - STOW_CONFIGURATION: Allow the user to customize the fixed stow arm
+ *    configuration.
  */
 export const SETTINGS_STATE = {
   MAIN: 'MAIN',
-  BITE_TRANSFER: 'BITE_TRANSFER',
+  DISTANCE_TO_MOUTH: 'DISTANCE_TO_MOUTH',
   ABOVE_PLATE: 'ABOVE_PLATE',
   RESTING_CONFIGURATION: 'RESTING_CONFIGURATION',
-  STAGING_CONFIGURATION: 'STAGING_CONFIGURATION'
+  STAGING_CONFIGURATION: 'STAGING_CONFIGURATION',
+  STOW_CONFIGURATION: 'STOW_CONFIGURATION'
 }
 
 // The name of the default parameter namespace

--- a/feedingwebapp/src/Pages/Settings/Main.jsx
+++ b/feedingwebapp/src/Pages/Settings/Main.jsx
@@ -158,13 +158,14 @@ const Main = () => {
   let moveAbovePlateConfigurationImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingAbovePlate]
   let moveToRestingConfigurationImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingToRestingPosition]
   let moveToStagingConfigurationImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingToStagingConfiguration]
+  let moveToStowConfigurationImage = MOVING_STATE_ICON_DICT[MEAL_STATE.R_StowingArm]
 
   // Configure the different options in the settings menu
   let settingsConfig = [
     {
-      title: 'Bite Transfer',
+      title: 'Distance to Mouth',
       icon: moveToMouthConfigurationImage,
-      onClick: () => onClickSettingsPage(SETTINGS_STATE.BITE_TRANSFER)
+      onClick: () => onClickSettingsPage(SETTINGS_STATE.DISTANCE_TO_MOUTH)
     },
     {
       title: 'Above Plate',
@@ -180,6 +181,11 @@ const Main = () => {
       title: 'Staging Position',
       icon: moveToStagingConfigurationImage,
       onClick: () => onClickSettingsPage(SETTINGS_STATE.STAGING_CONFIGURATION)
+    },
+    {
+      title: 'Stow Position',
+      icon: moveToStowConfigurationImage,
+      onClick: () => onClickSettingsPage(SETTINGS_STATE.STOW_CONFIGURATION)
     }
   ]
 
@@ -239,7 +245,7 @@ const Main = () => {
             <Button
               variant='outline-dark'
               style={{
-                fontSize: '30px',
+                fontSize: '25px',
                 display: 'flex',
                 flexDirection: 'row',
                 justifyContent: 'center',

--- a/feedingwebapp/src/Pages/Settings/Settings.jsx
+++ b/feedingwebapp/src/Pages/Settings/Settings.jsx
@@ -19,7 +19,8 @@ import {
   RESTING_PARAM_JOINTS_2,
   STAGING_PARAM_JOINTS,
   STAGING_PARAM_ORIENTATION,
-  STAGING_PARAM_POSITION
+  STAGING_PARAM_POSITION,
+  STOW_PARAM_JOINTS
 } from '../Constants'
 
 /**
@@ -34,13 +35,14 @@ const Settings = (props) => {
   const abovePlateParamNames = useMemo(() => [ABOVE_PLATE_PARAM_JOINTS], [])
   const restingParamNames = useMemo(() => [RESTING_PARAM_JOINTS_1, RESTING_PARAM_JOINTS_2], [])
   const stagingParamNames = useMemo(() => [STAGING_PARAM_JOINTS, STAGING_PARAM_POSITION, STAGING_PARAM_ORIENTATION], [])
+  const stowParamNames = useMemo(() => [STOW_PARAM_JOINTS], [])
 
   const getComponentBySettingsState = useCallback(() => {
     console.log('getComponentBySettingsState', settingsState)
     switch (settingsState) {
       case SETTINGS_STATE.MAIN:
         return <Main />
-      case SETTINGS_STATE.BITE_TRANSFER:
+      case SETTINGS_STATE.DISTANCE_TO_MOUTH:
         return <BiteTransfer webrtcURL={props.webrtcURL} />
       case SETTINGS_STATE.ABOVE_PLATE:
         return (
@@ -118,11 +120,29 @@ const Settings = (props) => {
             webrtcURL={props.webrtcURL}
           />
         )
+      case SETTINGS_STATE.STOW_CONFIGURATION:
+        return (
+          <CustomizeConfiguration
+            startingMealState={MEAL_STATE.R_StowingArm}
+            paramNames={stowParamNames}
+            getEndEffectorPose={false}
+            getParamValues={[getJointPositionsFromRobotStateResponse]}
+            configurationName='Stow Position'
+            buttonName='Stow Arm'
+            otherButtonConfigs={[
+              {
+                name: 'Move Above Plate',
+                mealState: MEAL_STATE.R_MovingAbovePlate
+              }
+            ]}
+            webrtcURL={props.webrtcURL}
+          />
+        )
       default:
         console.log('Invalid settings state', settingsState)
         return <Main />
     }
-  }, [abovePlateParamNames, restingParamNames, stagingParamNames, props.webrtcURL, settingsState])
+  }, [abovePlateParamNames, restingParamNames, stagingParamNames, stowParamNames, props.webrtcURL, settingsState])
 
   // Render the component
   return (


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

This PR builds off of recent PRs (#136 , #135 , etc.) to allow users to customize the stow configuration.

## Explain how this pull request was tested, including but not limited to the below checkmarks.

- [x] Launch the code in real: `python3 src/ada_feeding/start.py`
- [x] Ideally, sit in the wheelchair for all the below tests to ensure it feels safe.
- [x] Verify `Stow Position` Settings work:
    - [x] Regardless of what page you go to the Stow Position settings from, verify it moves to the stow position when you load it and moves back when you click "Done"
        - [x] Bite Selection
        - [x] Bite Acquisition Check
        - [x] Detecting Face
        - [x] Bite Done
    - [x] Teleop it, verify the parameters in the YAML file update.
    - [x] Click MoveAbovePlate. Verify it succeeds, and after that the teleop part is disabled.
    - [x] Click Stow Arm, and verify the teleop part gets re-enabled. Verify it moves to the customized stow configuration.
    - [x] Reset to default, verify that it updates the param file and immediately moves to the default stow configuration.
- [x] Find reasonable stow configurations for each of the default side configurations.

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [N/A] Format Python code by running `python3 -m black .` in the top-level of this repository
- [x] Thoroughly test your code's functionality, including unintended uses.
- [x] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [x] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
