### PR TITLE
Allow retaring the FT sensor from the teleop subcomponent

### DIFF
--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -118,6 +118,8 @@ ROS_SERVICE_NAMES[MEAL_STATE.U_BiteAcquisitionCheck] = {
 export { ROS_SERVICE_NAMES }
 export const CLEAR_OCTOMAP_SERVICE_NAME = 'clear_octomap'
 export const CLEAR_OCTOMAP_SERVICE_TYPE = 'std_srvs/srv/Empty'
+export const RETARE_FT_SENSOR_SERVICE_NAME = 'wireless_ft/set_bias'
+export const RETARE_FT_SENSOR_SERVICE_TYPE = 'std_srvs/srv/SetBool'
 export const ACQUISITION_REPORT_SERVICE_NAME = 'ada_feeding_action_select/action_report'
 export const ACQUISITION_REPORT_SERVICE_TYPE = 'ada_feeding_msgs/srv/AcquisitionReport'
 export const GET_ROBOT_STATE_SERVICE_NAME = 'get_robot_state'

--- a/feedingwebapp/src/Pages/Header/InfoModal.jsx
+++ b/feedingwebapp/src/Pages/Header/InfoModal.jsx
@@ -124,7 +124,7 @@ function InfoModal(props) {
           {mode === VIDEO_MODE ? (
             <VideoFeed topic={CAMERA_FEED_TOPIC} updateRateHz={10} webrtcURL={props.webrtcURL} />
           ) : mode === TELEOP_MODE ? (
-            <TeleopSubcomponent allowIncreasingForceThreshold={true} />
+            <TeleopSubcomponent allowIncreasingForceThreshold={true} allowRetaringFTSensor={true} />
           ) : mode === SYSTEM_STATUS_MODE ? (
             <div>System Status</div>
           ) : (


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

Sometimes, if the user is teleoperating the robot over a large trajectory, the F/T sensor will trip because it has moved too much since re-taring. As of now, there is no way to perform that re-taring in the web app. This PR addresses that by adding a button to the `TeleopSubcomponent`, always accessible through the `Info` modal, that allows users to re-tare the force-torque sensor.

## Explain how this pull request was tested, including but not limited to the below checkmarks.

- [x] Launch the system in `--sim mock`.
- [x] Go into the `Info` modal. Verify the re-tare button exists.
- [x] Click the re-tare button. Go to `screen -r ft`. Verify the request to re-tare was received.

## Future Work
Consider whether to add this to the customization pages as well.

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [N/A] Format Python code by running `python3 -m black .` in the top-level of this repository
- [ ] Thoroughly test your code's functionality, including unintended uses.
- [ ] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [ ] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
