### PR TITLE
Allow users to skip acquisition on error

### DIFF
--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -43,12 +43,6 @@ export const SERVO_CARTESIAN_TOPIC_MSG = 'geometry_msgs/msg/TwistStamped'
 export const SERVO_JOINT_TOPIC = '/web_app/servo_node/delta_joint_cmds'
 export const SERVO_JOINT_TOPIC_MSG = 'control_msgs/msg/JointJog'
 
-// States from which, if they fail, it is NOT okay for the user to retry the
-// same action.
-let NON_RETRYABLE_STATES = new Set()
-NON_RETRYABLE_STATES.add(MEAL_STATE.R_BiteAcquisition)
-export { NON_RETRYABLE_STATES }
-
 /**
  * For states that call ROS actions, this dictionary contains
  * the action name and the message type

--- a/feedingwebapp/src/Pages/Home/Home.jsx
+++ b/feedingwebapp/src/Pages/Home/Home.jsx
@@ -118,8 +118,9 @@ function Home(props) {
         let currentMealState = MEAL_STATE.R_BiteAcquisition
         let nextMealState = MEAL_STATE.U_BiteAcquisitionCheck
         let backMealState = MEAL_STATE.R_MovingAbovePlate
+        // TODO: Add an icon for this errorMealState!
         let errorMealState = MEAL_STATE.R_MovingToRestingPosition
-        let errorMealStateDescription = 'Proceed'
+        let errorMealStateDescription = 'Skip Acquisition'
         return (
           <RobotMotion
             debug={props.debug}

--- a/feedingwebapp/src/Pages/Home/Home.jsx
+++ b/feedingwebapp/src/Pages/Home/Home.jsx
@@ -118,6 +118,8 @@ function Home(props) {
         let currentMealState = MEAL_STATE.R_BiteAcquisition
         let nextMealState = MEAL_STATE.U_BiteAcquisitionCheck
         let backMealState = MEAL_STATE.R_MovingAbovePlate
+        let errorMealState = MEAL_STATE.R_MovingToRestingPosition
+        let errorMealStateDescription = 'Proceed'
         return (
           <RobotMotion
             debug={props.debug}
@@ -127,6 +129,9 @@ function Home(props) {
             backMealState={backMealState}
             actionInput={biteAcquisitionActionInput}
             waitingText={getRobotMotionText(currentMealState)}
+            allowRetry={false} // Don't allow retrying bite acquisition
+            errorMealState={errorMealState}
+            errorMealStateDescription={errorMealStateDescription}
           />
         )
       }

--- a/feedingwebapp/src/Pages/Home/MealStates/RobotMotion.jsx
+++ b/feedingwebapp/src/Pages/Home/MealStates/RobotMotion.jsx
@@ -289,12 +289,12 @@ const RobotMotion = (props) => {
    * @param {showTime} - indicates if elapsed time needs to be shown
    * @param {time} - calculated elapsed time, 0 if time not available
    * @param {progress} - progress proportion; if null progress bar not shown
-   * @param {retry} - indicates if retry needed for error
+   * @param {error} - indicates if there was an error
    *
    * @returns {JSX.Element} the action status text, progress bar or blank view
    */
   const actionStatusTextAndVisual = useCallback(
-    (flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress, retry = false) => {
+    (flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress, error = false) => {
       return (
         <>
           <View style={{ flex: flexSizeOuter, flexDirection: dimension, alignItems: 'center', justifyContent: 'center', width: '100%' }}>
@@ -304,35 +304,41 @@ const RobotMotion = (props) => {
               </p>
               <p style={{ fontSize: motionTextFontSize }}>{text}</p>
               {showTime ? <p style={{ fontSize: motionTextFontSize }}>&nbsp;&nbsp;Elapsed: {time} sec</p> : <></>}
-              {retry ? (
-                <Button
-                  variant='warning'
-                  className='mx-2 btn-huge'
-                  size='lg'
-                  onClick={retryCallback}
-                  style={{
-                    width: '90%',
-                    height: '20%'
-                  }}
-                >
-                  <h5 style={{ textAlign: 'center', fontSize: motionTextFontSize }}>Retry</h5>
-                </Button>
-              ) : (
-                <></>
-              )}
-              {props.errorMealState ? (
-                <Button
-                  variant='warning'
-                  className='mx-2 btn-huge'
-                  size='lg'
-                  onClick={() => changeMealState(props.errorMealState, 'errorMealState')}
-                  style={{
-                    width: '90%',
-                    height: '20%'
-                  }}
-                >
-                  <h5 style={{ textAlign: 'center', fontSize: motionTextFontSize }}>{props.errorMealStateDescription}</h5>
-                </Button>
+              {error ? (
+                <>
+                  {props.allowRetry ? (
+                    <Button
+                      variant='warning'
+                      className='mx-2 btn-huge'
+                      size='lg'
+                      onClick={retryCallback}
+                      style={{
+                        width: '90%',
+                        height: '20%'
+                      }}
+                    >
+                      <h5 style={{ textAlign: 'center', fontSize: motionTextFontSize }}>Retry</h5>
+                    </Button>
+                  ) : (
+                    <></>
+                  )}
+                  {props.errorMealState ? (
+                    <Button
+                      variant='warning'
+                      className='mx-2 btn-huge'
+                      size='lg'
+                      onClick={() => changeMealState(props.errorMealState, 'errorMealState')}
+                      style={{
+                        width: '90%',
+                        height: '20%'
+                      }}
+                    >
+                      <h5 style={{ textAlign: 'center', fontSize: motionTextFontSize }}>{props.errorMealStateDescription}</h5>
+                    </Button>
+                  ) : (
+                    <></>
+                  )}
+                </>
               ) : (
                 <></>
               )}
@@ -355,6 +361,7 @@ const RobotMotion = (props) => {
     [
       dimension,
       props.waitingText,
+      props.allowRetry,
       props.errorMealState,
       props.errorMealStateDescription,
       motionTextFontSize,
@@ -377,6 +384,7 @@ const RobotMotion = (props) => {
       let showTime = false
       let time = 0
       let progress = null
+      let error = false
       switch (actionStatus.actionStatus) {
         case ROS_ACTION_STATUS_EXECUTE:
           if (actionStatus.feedback) {
@@ -411,19 +419,9 @@ const RobotMotion = (props) => {
            * users on how to troubleshoot/fix it.
            */
           text = 'Robot encountered an error'
+          error = true
           return (
-            <>
-              {actionStatusTextAndVisual(
-                flexSizeOuter,
-                flexSizeTextInner,
-                flexSizeVisualInner,
-                text,
-                showTime,
-                time,
-                progress,
-                props.allowRetry
-              )}
-            </>
+            <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress, error)}</>
           )
         case ROS_ACTION_STATUS_CANCELED:
           return <>{actionStatusTextAndVisual(flexSizeOuter, flexSizeTextInner, flexSizeVisualInner, text, showTime, time, progress)}</>
@@ -441,7 +439,7 @@ const RobotMotion = (props) => {
           }
       }
     },
-    [paused, dimension, actionStatusTextAndVisual, props.allowRetry]
+    [paused, dimension, actionStatusTextAndVisual]
   )
 
   // Render the component


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

Sometimes, even though acquisition succeeds, the robot thinks it encountered an error. This PR shows the user the option to proceed to the resting position even if it gets an error, to account for that scenario.

## Explain how this pull request was tested, including but not limited to the below checkmarks.

- [x] Launch code in sim `mock`.
- [x] Before running acquisition, terminate the code in the `feeding` screen. Run acquisition.
- [x] Verify that it encounters an error and the "Skip Acquisition" button appears (but resume and retry don't).
- [x] Re-run the code in the `feeding` screen.
- [x] Click "Skip Acquisition" and verify it moves to the resting configuration.
- [x] Move to some other configuration (e.g., to staging) and cause an error e.g., terminating the code in the `feeding` screen before calling it).
- [x] Verify that the retry, resume, and back buttons appear.
- [x] Re-run the code in the `feeding` screen.
- [x] Click retry, verify it works.
- [x] Pause some motion (e.g., moving to resting). Verify back and resume appear.
- [x] Verify back works.
- [x] Verify resume works.

***

**Before creating a pull request**

- [ ] Format React code with `npm run format`
- [ ] Format Python code by running `python3 -m black .` in the top-level of this repository
- [ ] Thoroughly test your code's functionality, including unintended uses.
- [ ] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [ ] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
