### PR TITLE
Improve Acquisition Report

### DIFF
--- a/feedingwebapp/src/Pages/GlobalState.jsx
+++ b/feedingwebapp/src/Pages/GlobalState.jsx
@@ -130,8 +130,8 @@ export const useGlobalState = create(
       // message received from the face detection node where a
       // face was detected and within the distance bounds of the camera.
       moveToMouthActionGoal: null,
-      // Last RobotMotion action response
-      lastMotionActionResponse: null,
+      // Last RobotMotion action feedback message
+      lastMotionActionFeedback: null,
       // Whether or not the currently-executing robot motion was paused by the user.
       // NOTE: `paused` may no longer need to be in global state now that we have
       // the `inNonMovingState` flag.
@@ -218,9 +218,9 @@ export const useGlobalState = create(
         set(() => ({
           biteAcquisitionActionGoal: biteAcquisitionActionGoal
         })),
-      setLastMotionActionResponse: (lastMotionActionResponse) =>
+      setLastMotionActionFeedback: (lastMotionActionFeedback) =>
         set(() => ({
-          lastMotionActionResponse: lastMotionActionResponse
+          lastMotionActionFeedback: lastMotionActionFeedback
         })),
       setMoveToMouthActionGoal: (moveToMouthActionGoal) =>
         set(() => {

--- a/feedingwebapp/src/Pages/Home/Home.jsx
+++ b/feedingwebapp/src/Pages/Home/Home.jsx
@@ -119,7 +119,7 @@ function Home(props) {
         let nextMealState = MEAL_STATE.U_BiteAcquisitionCheck
         let backMealState = MEAL_STATE.R_MovingAbovePlate
         // TODO: Add an icon for this errorMealState!
-        let errorMealState = MEAL_STATE.R_MovingToRestingPosition
+        let errorMealState = MEAL_STATE.R_MovingToStagingConfiguration
         let errorMealStateDescription = 'Skip Acquisition'
         return (
           <RobotMotion

--- a/feedingwebapp/src/Pages/Home/Home.jsx
+++ b/feedingwebapp/src/Pages/Home/Home.jsx
@@ -1,10 +1,12 @@
 // React imports
-import React, { useCallback, useEffect, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 import PropTypes from 'prop-types'
+import { toast } from 'react-toastify'
 import { View } from 'react-native'
 
 // Local imports
 import './Home.css'
+import { createROSService, createROSServiceRequest, useROS } from '../../ros/ros_helpers'
 import { useGlobalState, MEAL_STATE } from '../GlobalState'
 import BiteAcquisitionCheck from './MealStates/BiteAcquisitionCheck'
 import BiteDone from './MealStates/BiteDone'
@@ -13,7 +15,13 @@ import DetectingFace from './MealStates/DetectingFace'
 import PostMeal from './MealStates/PostMeal'
 import PreMeal from './MealStates/PreMeal'
 import RobotMotion from './MealStates/RobotMotion'
-import { getRobotMotionText, TIME_TO_RESET_MS } from '../Constants'
+import {
+  ACQUISITION_REPORT_SERVICE_NAME,
+  ACQUISITION_REPORT_SERVICE_TYPE,
+  getRobotMotionText,
+  REGULAR_CONTAINER_ID,
+  TIME_TO_RESET_MS
+} from '../Constants'
 
 /**
  * The Home component displays the state of the meal, solicits user input as
@@ -79,6 +87,47 @@ function Home(props) {
   const moveToStowPositionActionInput = useMemo(() => ({}), [])
 
   /**
+   * Create callbacks for acquisition success and failure. This is done here because these
+   * callbacks can be called during BiteAcquisition or the BiteAcquisitionCheck.
+   */
+  const lastMotionActionFeedback = useGlobalState((state) => state.lastMotionActionFeedback)
+  const ros = useRef(useROS().ros)
+  let acquisitionReportService = useRef(createROSService(ros.current, ACQUISITION_REPORT_SERVICE_NAME, ACQUISITION_REPORT_SERVICE_TYPE))
+  let acquisitionResponse = useCallback(
+    (success) => {
+      if (!lastMotionActionFeedback.action_info_populated) {
+        console.info('Cannot report acquisition success or failure without action_info_populated.')
+        return
+      }
+      let msg, loss
+      if (success) {
+        msg = 'Reporting Food Acquisition Success!'
+        loss = 0.0
+      } else {
+        msg = 'Reporting Food Acquisition Failure.'
+        loss = 1.0
+      }
+      // NOTE: This uses the ToastContainer in Header
+      console.log(msg)
+      toast.info(msg, {
+        containerId: REGULAR_CONTAINER_ID,
+        toastId: msg
+      })
+      // Create a service request
+      let request = createROSServiceRequest({
+        loss: loss,
+        action_index: lastMotionActionFeedback.action_index,
+        posthoc: lastMotionActionFeedback.posthoc,
+        id: lastMotionActionFeedback.selection_id
+      })
+      // Call the service
+      let service = acquisitionReportService.current
+      service.callService(request, (response) => console.log('Got acquisition report response', response))
+    },
+    [lastMotionActionFeedback]
+  )
+
+  /**
    * Determines what screen to render based on the meal state.
    */
   const getComponentByMealState = useCallback(() => {
@@ -120,6 +169,7 @@ function Home(props) {
         let backMealState = MEAL_STATE.R_MovingAbovePlate
         // TODO: Add an icon for this errorMealState!
         let errorMealState = MEAL_STATE.R_MovingToStagingConfiguration
+        let errorCallback = () => acquisitionResponse(true) // Success if the user skips acquisition
         let errorMealStateDescription = 'Skip Acquisition'
         return (
           <RobotMotion
@@ -132,6 +182,7 @@ function Home(props) {
             waitingText={getRobotMotionText(currentMealState)}
             allowRetry={false} // Don't allow retrying bite acquisition
             errorMealState={errorMealState}
+            errorCallback={errorCallback}
             errorMealStateDescription={errorMealStateDescription}
           />
         )
@@ -153,7 +204,7 @@ function Home(props) {
         )
       }
       case MEAL_STATE.U_BiteAcquisitionCheck: {
-        return <BiteAcquisitionCheck debug={props.debug} />
+        return <BiteAcquisitionCheck debug={props.debug} acquisitionResponse={acquisitionResponse} />
       }
       case MEAL_STATE.R_MovingToStagingConfiguration: {
         /**
@@ -257,6 +308,7 @@ function Home(props) {
     props.debug,
     props.webrtcURL,
     biteAcquisitionActionInput,
+    acquisitionResponse,
     mostRecentBiteDoneResponse,
     moveAbovePlateActionInput,
     moveToMouthActionInput,

--- a/feedingwebapp/src/Pages/Settings/BiteTransfer.jsx
+++ b/feedingwebapp/src/Pages/Settings/BiteTransfer.jsx
@@ -64,7 +64,7 @@ const BiteTransfer = (props) => {
   // Indicator of how to arrange screen elements based on orientation
   let dimension = isPortrait ? 'column' : 'row'
   // Rendering variables
-  let textFontSize = '3.5vh'
+  let textFontSize = '3.0vh'
 
   // Get min and max distance to mouth
   const minDistanceToMouth = 1 // cm
@@ -227,9 +227,9 @@ const BiteTransfer = (props) => {
   const speedParameterIdsAndDescriptions = useMemo(
     () => [
       [moveToMouthSpeedId, 'Approach Speed (cm/s)'],
-      [moveToMouthSpeedNearMouthId, 'Approach Speed Near Mouth (cm/s)'],
+      [moveToMouthSpeedNearMouthId, 'Approach Near Mouth (cm/s)'],
       [moveFromMouthSpeedId, 'Retreat Speed (cm/s)'],
-      [moveFromMouthSpeedNearMouthId, 'Retreat Speed Near Mouth (cm/s)']
+      [moveFromMouthSpeedNearMouthId, 'Retreat Near Mouth (cm/s)']
     ],
     [moveToMouthSpeedId, moveToMouthSpeedNearMouthId, moveFromMouthSpeedId, moveFromMouthSpeedNearMouthId]
   )
@@ -264,7 +264,7 @@ const BiteTransfer = (props) => {
         >
           <View
             style={{
-              flex: 8,
+              flex: 16,
               flexDirection: 'column',
               justifyContent: 'center',
               alignItems: 'center',
@@ -335,7 +335,7 @@ const BiteTransfer = (props) => {
           </View>
           <View
             style={{
-              flex: 8,
+              flex: 5,
               flexDirection: 'column',
               justifyContent: 'center',
               alignItems: 'center',
@@ -366,14 +366,14 @@ const BiteTransfer = (props) => {
                 Move To Mouth
               </Button>
             </View>
-            <View
+            {/* <View
               style={{
                 flex: 1,
                 justifyContent: 'center',
                 alignItems: 'center',
                 width: '100%'
               }}
-            />
+            /> */}
             <View
               style={{
                 flex: 1,
@@ -397,14 +397,14 @@ const BiteTransfer = (props) => {
                 Move From Mouth
               </Button>
             </View>
-            <View
+            {/* <View
               style={{
                 flex: 1,
                 justifyContent: 'center',
                 alignItems: 'center',
                 width: '100%'
               }}
-            />
+            /> */}
           </View>
         </View>
       )

--- a/feedingwebapp/src/ros/ros_helpers.js
+++ b/feedingwebapp/src/ros/ros_helpers.js
@@ -157,6 +157,7 @@ export function callROSAction(actionClient, goal, feedbackCallback, resultCallba
   // server's callback list to prevent multiple callbacks from being executed in
   // further calls.
   actionClient.createClient(goal, resultCallback, feedbackCallback)
+  console.log('Called ROS Action')
 }
 
 /**


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

This PR allows a successful acquisition report even when the user clicks "Skip Acquisition" if acquisition failed (i.e., it failed after acquiring the food). The PR also makes "Skip Acquisition" go directly to the staging configuration.

Note: [`ada_feeding`#197](https://github.com/personalrobotics/ada_feeding/pull/197) should be merged before this!

## Explain how this pull request was tested, including but not limited to the below checkmarks.

- [x] Launch the code in `real`.
- [x] Acquire food, simulate a failure.
- [x] Verify that `Skip Acquisition` sends a successful acquisition report.
- [x] Acquire food, let it complete.
- [x] Verify that "Move To Mouth" sends a successful acquisition report.
- [x] Acquire food, let it complete.
- [x] Verify that "Re-acquire Bite" sends a failed acquisition report.
- [x] Go to staging, then cancel and go back to resting.
- [x] Click (one-at-a-time) "Move To Mouth" and "Re-acquire Food," verify that neither sends an acquisition report.

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [ ] Format Python code by running `python3 -m black .` in the top-level of this repository
- [ ] Thoroughly test your code's functionality, including unintended uses.
- [ ] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [ ] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
