### PR TITLE
Allow users to change auto-continue from Settings Menu

### DIFF
--- a/feedingwebapp/public/robot_state_imgs/forward.svg
+++ b/feedingwebapp/public/robot_state_imgs/forward.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_15_207)">
+<rect width="24" height="24" fill="white"/>
+<path d="M19.4422 10.3492L14.8796 5.02623C14.5775 4.67378 14 4.88743 14 5.35163V8C11 8 4 11 4 20C6 15 10 14 14 14V16.6484C14 17.1126 14.5775 17.3262 14.8796 16.9738L19.4422 11.6508C19.7632 11.2763 19.7632 10.7237 19.4422 10.3492Z" stroke="#000000" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_15_207">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/feedingwebapp/public/robot_state_imgs/forward.svg
+++ b/feedingwebapp/public/robot_state_imgs/forward.svg
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
-<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_15_207)">
-<rect width="24" height="24" fill="white"/>
-<path d="M19.4422 10.3492L14.8796 5.02623C14.5775 4.67378 14 4.88743 14 5.35163V8C11 8 4 11 4 20C6 15 10 14 14 14V16.6484C14 17.1126 14.5775 17.3262 14.8796 16.9738L19.4422 11.6508C19.7632 11.2763 19.7632 10.7237 19.4422 10.3492Z" stroke="#000000" stroke-linecap="round" stroke-linejoin="round"/>
-</g>
-<defs>
-<clipPath id="clip0_15_207">
-<rect width="24" height="24" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg version="1.1" id="Uploaded to svgrepo.com" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 width="800px" height="800px" viewBox="0 0 32 32" xml:space="preserve">
+<style type="text/css">
+	.sharpcorners_een{fill:#111918;}
+</style>
+<path class="sharpcorners_een" d="M14.284,30.964C7.439,30.59,2,24.938,2,18C2,11.158,7.289,5.563,14,5.051V1l12,10L14,21v-3.92
+	c-3.391,0.486-6,3.395-6,6.92C8,27.624,10.754,30.605,14.284,30.964z M18,1v2v0.032L27.562,11L18,18.968V21l12-10L18,1z"/>
 </svg>

--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -30,6 +30,7 @@ MOVING_STATE_ICON_DICT[MEAL_STATE.R_MovingToMouth] = '/robot_state_imgs/move_to_
 MOVING_STATE_ICON_DICT[MEAL_STATE.R_StowingArm] = '/robot_state_imgs/stowing_arm_position.svg'
 export { MOVING_STATE_ICON_DICT }
 export const TABLE_ICON = '/robot_state_imgs/table.svg'
+export const FORWARD_ICON = '/robot_state_imgs/forward.svg'
 
 // The names of the ROS topic(s)
 export const CAMERA_FEED_TOPIC = '/local/camera/color/image_raw/compressed'

--- a/feedingwebapp/src/Pages/GlobalState.jsx
+++ b/feedingwebapp/src/Pages/GlobalState.jsx
@@ -94,7 +94,8 @@ export const SETTINGS_STATE = {
   RESTING_CONFIGURATION: 'RESTING_CONFIGURATION',
   STAGING_CONFIGURATION: 'STAGING_CONFIGURATION',
   STOW_CONFIGURATION: 'STOW_CONFIGURATION',
-  PLANNING_SCENE: 'PLANNING_SCENE'
+  PLANNING_SCENE: 'PLANNING_SCENE',
+  AUTO_CONTINUE: 'AUTO_CONTINUE'
 }
 
 // The name of the default parameter namespace
@@ -140,7 +141,7 @@ export const useGlobalState = create(
       teleopAngularSpeed: 0.15, // rad/s
       teleopJointSpeed: 0.2, // rad/s
       // Flag to indicate whether to auto-continue after face detection
-      faceDetectionAutoContinue: true,
+      faceDetectionAutoContinue: false,
       // Flag to indicate whether to auto-continue in bite done after food-on-fork detection
       biteDoneAutoContinue: false,
       biteDoneAutoContinueSecs: 3.0,

--- a/feedingwebapp/src/Pages/Settings/AutoContinue.jsx
+++ b/feedingwebapp/src/Pages/Settings/AutoContinue.jsx
@@ -1,0 +1,137 @@
+// React imports
+import React, { useCallback, useMemo, useState } from 'react'
+import { View } from 'react-native'
+
+// Local imports
+import { useGlobalState, SETTINGS_STATE } from '../GlobalState'
+import SettingsPageParent from './SettingsPageParent'
+
+/**
+ * The AutoContinue component allows users to change the auto-continue settings
+ * from the Settings menu.
+ */
+const AutoContinue = () => {
+  // Get relevant global state variables
+  const setSettingsState = useGlobalState((state) => state.setSettingsState)
+  const biteAcquisitionCheckAutoContinue = useGlobalState((state) => state.biteAcquisitionCheckAutoContinue)
+  const setBiteAcquisitionCheckAutoContinue = useGlobalState((state) => state.setBiteAcquisitionCheckAutoContinue)
+  const faceDetectionAutoContinue = useGlobalState((state) => state.faceDetectionAutoContinue)
+  const setFaceDetectionAutoContinue = useGlobalState((state) => state.setFaceDetectionAutoContinue)
+  const biteDoneAutoContinue = useGlobalState((state) => state.biteDoneAutoContinue)
+  const setBiteDoneAutoContinue = useGlobalState((state) => state.setBiteDoneAutoContinue)
+
+  // Rendering variables
+  let textFontSize = '3.5vh'
+
+  // Configure the parameters for SettingsPageParent
+  const paramNames = useMemo(() => [], [])
+  const [currentParams, setCurrentParams] = useState([])
+
+  // Render the settings for the planning scene
+  const renderAutoContinueSettings = useCallback(() => {
+    return (
+      <View
+        style={{
+          flex: 1,
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          width: '100%',
+          height: '100%'
+        }}
+      >
+        <View
+          style={{
+            flex: 1,
+            flexDirection: 'row',
+            justifyContent: 'center',
+            alignItems: 'center',
+            width: '100%'
+          }}
+        >
+          <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+            <input
+              name='biteAcquisitionCheckAutoContinue'
+              type='checkbox'
+              checked={biteAcquisitionCheckAutoContinue}
+              onChange={(e) => {
+                setBiteAcquisitionCheckAutoContinue(e.target.checked)
+              }}
+              style={{ transform: 'scale(2.0)', verticalAlign: 'middle', marginRight: '15px' }}
+            />
+            Auto-continue after acquisition
+          </p>
+        </View>
+        <View
+          style={{
+            flex: 1,
+            flexDirection: 'row',
+            justifyContent: 'center',
+            alignItems: 'center',
+            width: '100%'
+          }}
+        >
+          <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+            <input
+              name='faceDetectionAutoContinue'
+              type='checkbox'
+              checked={faceDetectionAutoContinue}
+              onChange={(e) => {
+                setFaceDetectionAutoContinue(e.target.checked)
+              }}
+              style={{ transform: 'scale(2.0)', verticalAlign: 'middle', marginRight: '15px' }}
+            />
+            Auto-continue after face detection
+          </p>
+        </View>
+        <View
+          style={{
+            flex: 1,
+            flexDirection: 'row',
+            justifyContent: 'center',
+            alignItems: 'center',
+            width: '100%'
+          }}
+        >
+          <p className='transitionMessage' style={{ marginBottom: '0px', fontSize: textFontSize }}>
+            <input
+              name='biteDoneAutoContinue'
+              type='checkbox'
+              checked={biteDoneAutoContinue}
+              onChange={(e) => {
+                setBiteDoneAutoContinue(e.target.checked)
+              }}
+              style={{ transform: 'scale(2.0)', verticalAlign: 'middle', marginRight: '15px' }}
+            />
+            Auto-continue after transfer
+          </p>
+        </View>
+      </View>
+    )
+  }, [
+    textFontSize,
+    biteAcquisitionCheckAutoContinue,
+    setBiteAcquisitionCheckAutoContinue,
+    faceDetectionAutoContinue,
+    setFaceDetectionAutoContinue,
+    biteDoneAutoContinue,
+    setBiteDoneAutoContinue
+  ])
+
+  return (
+    <SettingsPageParent
+      title='Auto-Continue &#9881;'
+      doneCallback={() => setSettingsState(SETTINGS_STATE.MAIN)}
+      modalShow={false}
+      modalOnHide={null}
+      modalChildren={null}
+      paramNames={paramNames}
+      localParamValues={currentParams}
+      setLocalParamValues={setCurrentParams}
+    >
+      {renderAutoContinueSettings()}
+    </SettingsPageParent>
+  )
+}
+
+export default AutoContinue

--- a/feedingwebapp/src/Pages/Settings/Main.jsx
+++ b/feedingwebapp/src/Pages/Settings/Main.jsx
@@ -277,7 +277,7 @@ const Main = () => {
                   display: 'flex'
                 }}
                 alt={config.title}
-                className='center'
+                className='settingsImage'
               />
               <p
                 style={{

--- a/feedingwebapp/src/Pages/Settings/Main.jsx
+++ b/feedingwebapp/src/Pages/Settings/Main.jsx
@@ -21,7 +21,8 @@ import {
   REGULAR_CONTAINER_ID,
   SET_PARAMETERS_SERVICE_NAME,
   SET_PARAMETERS_SERVICE_TYPE,
-  TABLE_ICON
+  TABLE_ICON,
+  FORWARD_ICON
 } from '../Constants'
 
 /**
@@ -192,6 +193,11 @@ const Main = () => {
       title: 'Planning Scene',
       icon: TABLE_ICON,
       onClick: () => onClickSettingsPage(SETTINGS_STATE.PLANNING_SCENE)
+    },
+    {
+      title: 'Auto-Continue',
+      icon: FORWARD_ICON,
+      onClick: () => onClickSettingsPage(SETTINGS_STATE.AUTO_CONTINUE)
     }
   ]
 

--- a/feedingwebapp/src/Pages/Settings/Settings.jsx
+++ b/feedingwebapp/src/Pages/Settings/Settings.jsx
@@ -23,6 +23,7 @@ import {
   STOW_PARAM_JOINTS
 } from '../Constants'
 import PlanningScene from './PlanningScene'
+import AutoContinue from './AutoContinue'
 
 /**
  * The Settings components displays the appropriate settings page based on the
@@ -141,6 +142,8 @@ const Settings = (props) => {
         )
       case SETTINGS_STATE.PLANNING_SCENE:
         return <PlanningScene />
+      case SETTINGS_STATE.AUTO_CONTINUE:
+        return <AutoContinue />
       default:
         console.log('Invalid settings state', settingsState)
         return <Main />

--- a/feedingwebapp/src/Pages/Settings/SettingsPageParent.jsx
+++ b/feedingwebapp/src/Pages/Settings/SettingsPageParent.jsx
@@ -76,6 +76,11 @@ const SettingsPageParent = (props) => {
    */
   const setLocalParametersToGlobalValues = useCallback(
     (preset) => {
+      if (props.paramNames.length === 0) {
+        console.log('Skipping setLocalParametersToGlobalValues because there are no parameters to get.')
+        return
+      }
+
       let service = getParametersService.current
       let setLocalParamValues = props.setLocalParamValues
 
@@ -134,6 +139,10 @@ const SettingsPageParent = (props) => {
    * Save the current parameter values to the current namespace.
    */
   const setGlobalParameter = useCallback(() => {
+    if (props.paramNames.length === 0) {
+      console.log('Skipping setGlobalParameter because there are no parameters to set.')
+      return
+    }
     if (props.localParamValues.every((element) => element === null)) {
       console.log('Skipping setGlobalParameter because all values are null.')
       return
@@ -240,42 +249,46 @@ const SettingsPageParent = (props) => {
           height: '100%'
         }}
       >
-        <View
-          style={{
-            flex: 4,
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: '100%',
-            height: '100%',
-            zIndex: 1
-          }}
-        >
-          <p style={{ textAlign: 'center', fontSize: textFontSize.toString() + sizeSuffix, margin: 0 }} className='txt-huge'>
-            {props.title}
-          </p>
-          <SplitButton
-            variant='secondary'
-            className='mx-2 mb-2 btn-huge'
-            size='lg'
+        {props.paramNames.length === 0 ? (
+          <></>
+        ) : (
+          <View
             style={{
-              fontSize: textFontSize.toString() + sizeSuffix,
-              marginLeft: '1rem'
+              flex: 4,
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '100%',
+              height: '100%',
+              zIndex: 1
             }}
-            title={settingsPresets.current}
           >
-            <Dropdown.Item key={DEFAULT_NAMESPACE} onClick={() => resetToPreset(DEFAULT_NAMESPACE)}>
-              Reset parameter to {DEFAULT_NAMESPACE}
-            </Dropdown.Item>
-            {settingsPresets.customNames
-              .filter((preset) => preset !== settingsPresets.current)
-              .map((preset) => (
-                <Dropdown.Item key={preset} onClick={() => resetToPreset(preset)}>
-                  Reset parameter to {preset}
-                </Dropdown.Item>
-              ))}
-          </SplitButton>
-        </View>
+            <p style={{ textAlign: 'center', fontSize: textFontSize.toString() + sizeSuffix, margin: 0 }} className='txt-huge'>
+              {props.title}
+            </p>
+            <SplitButton
+              variant='secondary'
+              className='mx-2 mb-2 btn-huge'
+              size='lg'
+              style={{
+                fontSize: textFontSize.toString() + sizeSuffix,
+                marginLeft: '1rem'
+              }}
+              title={settingsPresets.current}
+            >
+              <Dropdown.Item key={DEFAULT_NAMESPACE} onClick={() => resetToPreset(DEFAULT_NAMESPACE)}>
+                Reset parameter to {DEFAULT_NAMESPACE}
+              </Dropdown.Item>
+              {settingsPresets.customNames
+                .filter((preset) => preset !== settingsPresets.current)
+                .map((preset) => (
+                  <Dropdown.Item key={preset} onClick={() => resetToPreset(preset)}>
+                    Reset parameter to {preset}
+                  </Dropdown.Item>
+                ))}
+            </SplitButton>
+          </View>
+        )}
         <View
           style={{
             flex: 32,


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

This PR adds another element to the settings menu that allows users to toggle auto-continue options. Although auto-continue options nominally can be toggled from the app, the issue is that once they are checked, the robot could potentially move past that screen very fast, so the user may not have time to un-toggle the auto-continue settings. This PR addresses that, by giving users another location (in the settings menu) to toggle auto-continue settings.

## Explain how this pull request was tested, including but not limited to the below checkmarks.

- [x] Launch the code in sim `mock`.
- [x] Load the settings menu, go into Auto-Continue.
- [x] Verify everything looks good.
- [x] Toggle each of the buttons (one-at-a-time), go through a bite, verify the right buttons are toggled.

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [ ] Format Python code by running `python3 -m black .` in the top-level of this repository
- [ ] Thoroughly test your code's functionality, including unintended uses.
- [ ] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [ ] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
