### PR TITLE
Create option to show Video Feed in Teleop Modal

### DIFF
--- a/feedingwebapp/src/Pages/Header/InfoModal.jsx
+++ b/feedingwebapp/src/Pages/Header/InfoModal.jsx
@@ -124,7 +124,41 @@ function InfoModal(props) {
           {mode === VIDEO_MODE ? (
             <VideoFeed topic={CAMERA_FEED_TOPIC} updateRateHz={10} webrtcURL={props.webrtcURL} />
           ) : mode === TELEOP_MODE ? (
-            <TeleopSubcomponent allowIncreasingForceThreshold={true} allowRetaringFTSensor={true} />
+            <View
+              style={{
+                flex: 1,
+                flexDirection: 'column',
+                justifyContent: 'center',
+                alignItems: 'center',
+                width: '100%',
+                height: '100%'
+              }}
+            >
+              <View
+                style={{
+                  flex: 5,
+                  flexDirection: 'column',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  width: '100%',
+                  height: '100%'
+                }}
+              >
+                <VideoFeed topic={CAMERA_FEED_TOPIC} updateRateHz={10} webrtcURL={props.webrtcURL} />
+              </View>
+              <View
+                style={{
+                  flex: 7,
+                  flexDirection: 'column',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  width: '100%',
+                  height: '100%'
+                }}
+              >
+                <TeleopSubcomponent allowIncreasingForceThreshold={true} allowRetaringFTSensor={true} />
+              </View>
+            </View>
           ) : mode === SYSTEM_STATUS_MODE ? (
             <div>System Status</div>
           ) : (

--- a/feedingwebapp/src/Pages/Header/InfoModal.jsx
+++ b/feedingwebapp/src/Pages/Header/InfoModal.jsx
@@ -134,18 +134,22 @@ function InfoModal(props) {
                 height: '100%'
               }}
             >
-              <View
-                style={{
-                  flex: 5,
-                  flexDirection: 'column',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  width: '100%',
-                  height: '100%'
-                }}
-              >
-                <VideoFeed topic={CAMERA_FEED_TOPIC} updateRateHz={10} webrtcURL={props.webrtcURL} />
-              </View>
+              {props.showVideoFeedDuringTeleop ? (
+                <View
+                  style={{
+                    flex: 5,
+                    flexDirection: 'column',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    width: '100%',
+                    height: '100%'
+                  }}
+                >
+                  <VideoFeed topic={CAMERA_FEED_TOPIC} updateRateHz={10} webrtcURL={props.webrtcURL} />
+                </View>
+              ) : (
+                <></>
+              )}
               <View
                 style={{
                   flex: 7,
@@ -175,7 +179,12 @@ InfoModal.propTypes = {
   // Callback function for when the modal is hidden
   onHide: PropTypes.func.isRequired,
   // The URL of the webrtc signalling server
-  webrtcURL: PropTypes.string.isRequired
+  webrtcURL: PropTypes.string.isRequired,
+  // Whether to show the video feed when teleoperating the robot
+  showVideoFeedDuringTeleop: PropTypes.bool.isRequired
+}
+InfoModal.defaultProps = {
+  showVideoFeedDuringTeleop: false
 }
 
 export default InfoModal


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

This PR, Motivated by the 2024 deployment, creates the option to show the video feed in the Teleop modal. In practice, this works fine when the user is accessing the modal on their computer, but not great on a screen as smart as the smartphone. Thus, by default, we disable this.

## Explain how this pull request was tested, including but not limited to the below checkmarks.

- [x] Run it, open the teleop modal, verify the video stream doesn't show.
- [x] Change `showVideoFeedDuringTeleop`'s default value to true, run it, verify it does show.

***

**Before creating a pull request**

- [x] Format React code with `npm run format`
- [N/A] Format Python code by running `python3 -m black .` in the top-level of this repository
- [x] Thoroughly test your code's functionality, including unintended uses.
- [x] Fully test the responsiveness of the feature as documented in the [Responsiveness Testing Guidelines](https://github.com/personalrobotics/feeding_web_interface/blob/main/feedingwebapp/ResponsivenessTesting.md). If you deviate from those guidelines, document above why you deviated and what you did instead.
- [x] Consider the user flow between states that this feature introduces, consider different situations that might occur for the user, and ensure that there is no way for the user to get stuck in a loop.

**Before merging a pull request**

- [ ] Squash all your commits into one (or `Squash and Merge`)
