### PR TITLE
Update F/T Sensor Re-tare Service Name for Articutool Integration

### DIFF
--- a/feedingwebapp/src/Pages/Constants.js
+++ b/feedingwebapp/src/Pages/Constants.js
@@ -119,7 +119,7 @@ ROS_SERVICE_NAMES[MEAL_STATE.U_BiteAcquisitionCheck] = {
 export { ROS_SERVICE_NAMES }
 export const CLEAR_OCTOMAP_SERVICE_NAME = 'clear_octomap'
 export const CLEAR_OCTOMAP_SERVICE_TYPE = 'std_srvs/srv/Empty'
-export const RETARE_FT_SENSOR_SERVICE_NAME = 'wireless_ft/set_bias'
+export const RETARE_FT_SENSOR_SERVICE_NAME = 'ft_sensor/tare'
 export const RETARE_FT_SENSOR_SERVICE_TYPE = 'std_srvs/srv/SetBool'
 export const ACQUISITION_REPORT_SERVICE_NAME = 'ada_feeding_action_select/action_report'
 export const ACQUISITION_REPORT_SERVICE_TYPE = 'ada_feeding_msgs/srv/AcquisitionReport'


### PR DESCRIPTION
## Describe this pull request. Link to relevant GitHub issues, if any.

This PR updates the service name used by the web interface to zero (tare) the Force/Torque sensor. This aligns the frontend with the recent infrastructure changes in the `ada_ros2` and `articutool_ros2` packages.

## Key Changes:
`feedingwebapp/src/Pages/Constants.js`: Updated `RETARE_FT_SENSOR_SERVICE_NAME` from 'wireless_ft/set_bias' to 'ft_sensor/tare'.

## Context:
Without this change, the "Re-tare Sensor" button in the web interface will fail to locate the service, as the underlying driver node has been updated to publish/subscribe to the new namespace.

**Before merging a pull request**

- \[ \] Squash all your commits into one (or `Squash and Merge`)
